### PR TITLE
Detect lowercase licence.md in github.com/josharian/intern. 

### DIFF
--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -77,6 +77,17 @@ loop:
 			// This is a template file for generated code,
 			// not an actual license file.
 			continue loop
+		case "github.com/josharian/intern/license.md":
+			// This is the actual license file although it's lowercase
+			ls := IdentifyLicenses(filebody)
+			if len(ls) == 0 {
+				return nil, fmt.Errorf("could not identify license in file %q", filename)
+			}
+			for l := range ls {
+				licenses[l] = struct{}{}
+			}
+			hasLicenseFile = true
+			continue loop
 		}
 
 		name := filepath.Base(filename)


### PR DESCRIPTION
The package github.com/josharian/intern (implicitly required by more
recent versions of `k8s.io/kube-openapi`) has an undetected MIT-license.
This commit adds a special case for it.