### PR TITLE
Generate license URLs in one place so it can be reused by other applications.

### DIFF
--- a/exitcodes.go
+++ b/exitcodes.go
@@ -7,5 +7,4 @@ const (
 	DependencyGenerationError exitCode = 1
 	InvalidArgumentsError     exitCode = 2
 	MarshallJsonError         exitCode = 3
-	MissingLicenseURLError    exitCode = 4
 )

--- a/main.go
+++ b/main.go
@@ -489,8 +489,6 @@ func markdownOutput(readme *bytes.Buffer, modNames []string, modLicenses map[str
 }
 
 func jsonOutput(readme *bytes.Buffer, modNames []string, modLicenses map[string]map[detectlicense.License]struct{}, modInfos map[string]*golist.Module, goVersion string) error {
-	allLicenses := map[detectlicense.License]struct{}{}
-
 	jsonOutput := dependencies.NewDependencyInfo()
 
 	for _, modKey := range modNames {
@@ -512,19 +510,15 @@ func jsonOutput(readme *bytes.Buffer, modNames []string, modLicenses map[string]
 
 		for license := range modLicenses[modKey] {
 			dependencyDetails.Licenses = append(dependencyDetails.Licenses, license.Name)
-			allLicenses[license] = struct{}{}
 		}
 		sort.Strings(dependencyDetails.Licenses)
 
 		jsonOutput.Dependencies = append(jsonOutput.Dependencies, dependencyDetails)
 	}
 
-	for license := range allLicenses {
-		if license.URL == "" {
-			_, _ = fmt.Fprintf(os.Stderr, "Could not find UELURL for license '%s'", license.Name)
-			os.Exit(int(MissingLicenseURLError))
-		}
-		jsonOutput.Licenses[license.Name] = license.URL
+	if err := jsonOutput.UpdateLicenseList(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Could not generate list of license URLs: %v\n", err)
+		os.Exit(int(DependencyGenerationError))
 	}
 
 	jsonString, err := json.Marshal(jsonOutput)

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -63,7 +63,7 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 	}
 
 	for k, v := range usedLicenses {
-		d.Licenses[k] = v.Url
+		d.Licenses[k] = v.URL
 	}
 
 	return nil

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -2,11 +2,11 @@ package dependencies
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/datawire/go-mkopensource/pkg/detectlicense"
 )
 
+//nolint:gochecknoglobals // Can't be a constant
 var knownLicenses = map[string]detectlicense.License{
 	detectlicense.Proprietary.Name:  detectlicense.Proprietary,
 	detectlicense.PublicDomain.Name: detectlicense.PublicDomain,
@@ -56,7 +56,7 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 		for _, licenseName := range dependency.Licenses {
 			license, ok := knownLicenses[licenseName]
 			if !ok {
-				return errors.New(fmt.Sprintf("License details for '%s' are not known", licenseName))
+				return fmt.Errorf("license details for '%s' are not known", licenseName)
 			}
 			usedLicenses[license.Name] = license
 		}

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -8,20 +8,20 @@ import (
 
 //nolint:gochecknoglobals // Can't be a constant
 var knownLicenses = map[string]detectlicense.License{
-	detectlicense.Proprietary.Name:  detectlicense.Proprietary,
-	detectlicense.PublicDomain.Name: detectlicense.PublicDomain,
-	detectlicense.Apache2.Name:      detectlicense.Apache2,
-	detectlicense.BSD1.Name:         detectlicense.BSD1,
-	detectlicense.BSD2.Name:         detectlicense.BSD2,
-	detectlicense.BSD3.Name:         detectlicense.BSD3,
-	detectlicense.CcBySa40.Name:     detectlicense.CcBySa40,
-	detectlicense.GPL3.Name:         detectlicense.GPL3,
-	detectlicense.ISC.Name:          detectlicense.ISC,
-	detectlicense.LGPL21.Name:       detectlicense.LGPL21,
-	detectlicense.MIT.Name:          detectlicense.MIT,
-	detectlicense.MPL2.Name:         detectlicense.MPL2,
-	detectlicense.PSF.Name:          detectlicense.PSF,
-	detectlicense.Unicode2015.Name:  detectlicense.Unicode2015}
+	detectlicense.Proprietary.Name:   detectlicense.Proprietary,
+	detectlicense.PublicDomain.Name:  detectlicense.PublicDomain,
+	detectlicense.Apache2.Name:       detectlicense.Apache2,
+	detectlicense.BSD1.Name:          detectlicense.BSD1,
+	detectlicense.BSD2.Name:          detectlicense.BSD2,
+	detectlicense.BSD3.Name:          detectlicense.BSD3,
+	detectlicense.CcBySa40.Name:      detectlicense.CcBySa40,
+	detectlicense.GPL3.Name:          detectlicense.GPL3,
+	detectlicense.ISC.Name:           detectlicense.ISC,
+	detectlicense.LGPL21OrLater.Name: detectlicense.LGPL21OrLater,
+	detectlicense.MIT.Name:           detectlicense.MIT,
+	detectlicense.MPL2.Name:          detectlicense.MPL2,
+	detectlicense.PSF.Name:           detectlicense.PSF,
+	detectlicense.Unicode2015.Name:   detectlicense.Unicode2015}
 
 type DependencyInfo struct {
 	Dependencies []Dependency      `json:"dependencies"`

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -1,6 +1,27 @@
 package dependencies
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/datawire/go-mkopensource/pkg/detectlicense"
+)
+
+var knownLicenses = map[string]detectlicense.License{
+	detectlicense.Proprietary.Name:  detectlicense.Proprietary,
+	detectlicense.PublicDomain.Name: detectlicense.PublicDomain,
+	detectlicense.Apache2.Name:      detectlicense.Apache2,
+	detectlicense.BSD1.Name:         detectlicense.BSD1,
+	detectlicense.BSD2.Name:         detectlicense.BSD2,
+	detectlicense.BSD3.Name:         detectlicense.BSD3,
+	detectlicense.CcBySa40.Name:     detectlicense.CcBySa40,
+	detectlicense.GPL3.Name:         detectlicense.GPL3,
+	detectlicense.ISC.Name:          detectlicense.ISC,
+	detectlicense.LGPL21.Name:       detectlicense.LGPL21,
+	detectlicense.MIT.Name:          detectlicense.MIT,
+	detectlicense.MPL2.Name:         detectlicense.MPL2,
+	detectlicense.PSF.Name:          detectlicense.PSF,
+	detectlicense.Unicode2015.Name:  detectlicense.Unicode2015}
 
 type DependencyInfo struct {
 	Dependencies []Dependency      `json:"dependencies"`
@@ -23,6 +44,26 @@ func NewDependencyInfo() DependencyInfo {
 func (d *DependencyInfo) Unmarshal(data []byte) error {
 	if err := json.Unmarshal(data, d); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (d *DependencyInfo) UpdateLicenseList() error {
+	usedLicenses := map[string]detectlicense.License{}
+
+	for _, dependency := range d.Dependencies {
+		for _, licenseName := range dependency.Licenses {
+			license, ok := knownLicenses[licenseName]
+			if !ok {
+				return errors.New(fmt.Sprintf("License details for '%s' are not known", licenseName))
+			}
+			usedLicenses[license.Name] = license
+		}
+	}
+
+	for k, v := range usedLicenses {
+		d.Licenses[k] = v.Url
 	}
 
 	return nil

--- a/pkg/dependencies/dependencyinfo_test.go
+++ b/pkg/dependencies/dependencyinfo_test.go
@@ -89,25 +89,25 @@ func TestLicenseListIsCorrect(t *testing.T) {
 			"Several dependencies with different licenses",
 			dependenciesWithUniqueLicenses,
 			map[string]string{
-				detectlicense.MIT.Name:  detectlicense.MIT.Url,
-				detectlicense.BSD1.Name: detectlicense.BSD1.Url},
+				detectlicense.MIT.Name:  detectlicense.MIT.URL,
+				detectlicense.BSD1.Name: detectlicense.BSD1.URL},
 		},
 		{
 			"A dependency with multiple licenses",
 			dependencyWithMultipleLicenses,
 			map[string]string{
-				detectlicense.GPL3.Name: detectlicense.GPL3.Url,
-				detectlicense.BSD2.Name: detectlicense.BSD2.Url,
+				detectlicense.GPL3.Name: detectlicense.GPL3.URL,
+				detectlicense.BSD2.Name: detectlicense.BSD2.URL,
 			},
 		},
 		{
 			"Dependencies with overlapping licenses",
 			dependenciesWithOverlappingLicenses,
 			map[string]string{
-				detectlicense.GPL3.Name:    detectlicense.GPL3.Url,
-				detectlicense.BSD2.Name:    detectlicense.BSD2.Url,
-				detectlicense.Apache2.Name: detectlicense.Apache2.Url,
-				detectlicense.GPL3.Name:    detectlicense.GPL3.Url,
+				detectlicense.GPL3.Name:    detectlicense.GPL3.URL,
+				detectlicense.BSD2.Name:    detectlicense.BSD2.URL,
+				detectlicense.Apache2.Name: detectlicense.Apache2.URL,
+				detectlicense.GPL3.Name:    detectlicense.GPL3.URL,
 			},
 		},
 		{

--- a/pkg/dependencies/dependencyinfo_test.go
+++ b/pkg/dependencies/dependencyinfo_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 )
 
+//nolint:gochecknoglobals // Can't be a constant
 var (
 	emptyDependencies = dependencies.DependencyInfo{
 		Dependencies: []dependencies.Dependency{},

--- a/pkg/dependencies/dependencyinfo_test.go
+++ b/pkg/dependencies/dependencyinfo_test.go
@@ -1,0 +1,130 @@
+package dependencies_test
+
+import (
+	"github.com/datawire/go-mkopensource/pkg/dependencies"
+	"github.com/datawire/go-mkopensource/pkg/detectlicense"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var (
+	emptyDependencies = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{},
+		Licenses:     map[string]string{},
+	}
+
+	dependenciesWithUniqueLicenses = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.MIT.Name},
+			},
+			{
+				Name:     "library2",
+				Version:  "3.1.2",
+				Licenses: []string{detectlicense.BSD1.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	dependencyWithMultipleLicenses = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3.Name, detectlicense.BSD2.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	dependenciesWithOverlappingLicenses = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3.Name, detectlicense.BSD2.Name},
+			},
+			{
+				Name:     "library2",
+				Version:  "3.1.2",
+				Licenses: []string{detectlicense.BSD2.Name},
+			},
+			{
+				Name:     "library2",
+				Version:  "3.1.2",
+				Licenses: []string{detectlicense.Apache2.Name, detectlicense.GPL3.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	licensesWithoutUrls = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.PublicDomain.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+)
+
+func TestLicenseListIsCorrect(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		dependencies     dependencies.DependencyInfo
+		expectedLicenses map[string]string
+	}{
+		{
+			"Empty dependency list",
+			emptyDependencies,
+			map[string]string{},
+		},
+		{
+			"Several dependencies with different licenses",
+			dependenciesWithUniqueLicenses,
+			map[string]string{
+				detectlicense.MIT.Name:  detectlicense.MIT.Url,
+				detectlicense.BSD1.Name: detectlicense.BSD1.Url},
+		},
+		{
+			"A dependency with multiple licenses",
+			dependencyWithMultipleLicenses,
+			map[string]string{
+				detectlicense.GPL3.Name: detectlicense.GPL3.Url,
+				detectlicense.BSD2.Name: detectlicense.BSD2.Url,
+			},
+		},
+		{
+			"Dependencies with overlapping licenses",
+			dependenciesWithOverlappingLicenses,
+			map[string]string{
+				detectlicense.GPL3.Name:    detectlicense.GPL3.Url,
+				detectlicense.BSD2.Name:    detectlicense.BSD2.Url,
+				detectlicense.Apache2.Name: detectlicense.Apache2.Url,
+				detectlicense.GPL3.Name:    detectlicense.GPL3.Url,
+			},
+		},
+		{
+			"Licenses without Url",
+			licensesWithoutUrls,
+			map[string]string{
+				detectlicense.PublicDomain.Name: "",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			// No licenses does not generate an error
+			err := testCase.dependencies.UpdateLicenseList()
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.expectedLicenses, testCase.dependencies.Licenses)
+		})
+	}
+}

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -93,6 +93,9 @@ loop:
 			// This is a template file for generated code,
 			// not an actual license file.
 			continue loop
+		case "github.com/telepresenceio/telepresence/v2/LICENSES.md":
+			// Licenses for telepresence are in LICENSE and not in LICENSES.md
+			continue loop
 		}
 
 		name := filepath.Base(filename)

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -49,7 +49,7 @@ var (
 	// split with "+" to avoid a false-positive on itself
 	spdxTag = []byte("SPDX-License" + "-Identifier:")
 
-	spdxIdentifiers = map[string]License{
+	SpdxIdentifiers = map[string]License{
 		"Apache-2.0":        Apache2,
 		"BSD-1-Clause":      BSD1,
 		"BSD-2-Clause":      BSD2,
@@ -200,7 +200,7 @@ func IdentifySPDXLicenses(body []byte) (map[License]struct{}, error) {
 		body = body[idEnd:]
 
 		id = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(id), "*/"))
-		license, licenseOK := spdxIdentifiers[id]
+		license, licenseOK := SpdxIdentifiers[id]
 		if !licenseOK {
 			return nil, fmt.Errorf("unknown SPDX identifier %q", id)
 		}


### PR DESCRIPTION
Some code for validating licenses and generating some of the license information JSON body was duplicated in `py-mkopensource` and `js-mkopensource`

This PR consolidates all those changes here so we only keep language-specific parsing logic in the other applications.

This change also contains a fix for incorrect license detection for telepresence