### PR TITLE
[WIP] Check license restrictions

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,10 +154,12 @@ func loadGoTar(goTarFilename string) (version string, license []byte, err error)
 
 func licenseIsProprietary(licenses map[detectlicense.License]struct{}) (bool, error) {
 	_, proprietary := licenses[detectlicense.Proprietary]
-	if proprietary && len(licenses) != 1 {
-		return false, errors.New("mixed proprietary and open-source licenses")
+	// For now fail anything with a proprietary license.
+	// TODO: aosorio - In the future the correct logic sould be to only accept proprietary licenses on Ambassador owned software.
+	if proprietary {
+		return true, errors.New("proprietary licenses are used")
 	}
-	return proprietary, nil
+	return false, nil
 }
 
 func licenseIsWeakCopyleft(licenses map[detectlicense.License]struct{}) bool {

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -7,20 +7,33 @@ import (
 )
 
 //nolint:gochecknoglobals // Can't be a constant
-var knownLicenses = map[string]detectlicense.License{
-	detectlicense.Proprietary.Name:   detectlicense.Proprietary,
-	detectlicense.PublicDomain.Name:  detectlicense.PublicDomain,
+var licensesByName = map[string]detectlicense.License{
 	detectlicense.Apache2.Name:       detectlicense.Apache2,
+	detectlicense.AGPL1Only.Name:     detectlicense.AGPL1Only,
+	detectlicense.AGPL1OrLater.Name:  detectlicense.AGPL1OrLater,
+	detectlicense.AGPL3Only.Name:     detectlicense.AGPL3Only,
+	detectlicense.AGPL3OrLater.Name:  detectlicense.AGPL3OrLater,
 	detectlicense.BSD1.Name:          detectlicense.BSD1,
 	detectlicense.BSD2.Name:          detectlicense.BSD2,
 	detectlicense.BSD3.Name:          detectlicense.BSD3,
 	detectlicense.CcBySa40.Name:      detectlicense.CcBySa40,
-	detectlicense.GPL3.Name:          detectlicense.GPL3,
+	detectlicense.GPL1Only.Name:      detectlicense.GPL1Only,
+	detectlicense.GPL1OrLater.Name:   detectlicense.GPL1OrLater,
+	detectlicense.GPL2Only.Name:      detectlicense.GPL2Only,
+	detectlicense.GPL2OrLater.Name:   detectlicense.GPL2OrLater,
+	detectlicense.GPL3Only.Name:      detectlicense.GPL3Only,
+	detectlicense.GPL3OrLater.Name:   detectlicense.GPL3OrLater,
 	detectlicense.ISC.Name:           detectlicense.ISC,
+	detectlicense.LGPL2Only.Name:     detectlicense.LGPL2Only,
+	detectlicense.LGPL2OrLater.Name:  detectlicense.LGPL2OrLater,
+	detectlicense.LGPL21Only.Name:    detectlicense.LGPL21Only,
 	detectlicense.LGPL21OrLater.Name: detectlicense.LGPL21OrLater,
+	detectlicense.LGPL3Only.Name:     detectlicense.LGPL3Only,
+	detectlicense.LGPL3OrLater.Name:  detectlicense.LGPL3OrLater,
 	detectlicense.MIT.Name:           detectlicense.MIT,
 	detectlicense.MPL2.Name:          detectlicense.MPL2,
 	detectlicense.PSF.Name:           detectlicense.PSF,
+	detectlicense.PublicDomain.Name:  detectlicense.PublicDomain,
 	detectlicense.Unicode2015.Name:   detectlicense.Unicode2015}
 
 type DependencyInfo struct {
@@ -54,9 +67,9 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 
 	for _, dependency := range d.Dependencies {
 		for _, licenseName := range dependency.Licenses {
-			license, ok := knownLicenses[licenseName]
-			if !ok {
-				return fmt.Errorf("license details for '%s' are not known", licenseName)
+			license, err := getLicenseFromName(licenseName)
+			if err != nil {
+				return err
 			}
 			usedLicenses[license.Name] = license
 		}
@@ -66,5 +79,40 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 		d.Licenses[k] = v.URL
 	}
 
+	return nil
+}
+
+func getLicenseFromName(licenseName string) (detectlicense.License, error) {
+	license, ok := licensesByName[licenseName]
+	if !ok {
+		return detectlicense.License{}, fmt.Errorf("license details for '%s' are not known", licenseName)
+	}
+	return license, nil
+}
+
+// CheckLicenses checks that the licenses used by the dependencies are known and allowed to be used
+//in an application based on the buiness logic described here: https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157.
+//This function must be called after parsing of the licenses has been done.
+func (d *DependencyInfo) CheckLicenses(allowedLicenses detectlicense.AllowedLicenseUse) error {
+	if allowedLicenses == detectlicense.Forbidden {
+		return fmt.Errorf("forbidden licenses should not be used")
+	}
+
+	for _, dependency := range d.Dependencies {
+		for _, licenseName := range dependency.Licenses {
+			license, err := getLicenseFromName(licenseName)
+			if err != nil {
+				return err
+			}
+
+			if license.AllowedUse == detectlicense.Forbidden {
+				return fmt.Errorf("license '%s' is forbidden", license.Name)
+			}
+
+			if license.AllowedUse < allowedLicenses {
+				return fmt.Errorf("license '%s' should not be used since it doesn't meet the useage requirements", license.Name)
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/dependencies/dependencyinfo_test.go
+++ b/pkg/dependencies/dependencyinfo_test.go
@@ -35,7 +35,7 @@ var (
 			{
 				Name:     "library1",
 				Version:  "1.0.2",
-				Licenses: []string{detectlicense.GPL3.Name, detectlicense.BSD2.Name},
+				Licenses: []string{detectlicense.GPL3Only.Name, detectlicense.BSD2.Name},
 			},
 		},
 		Licenses: map[string]string{},
@@ -46,7 +46,7 @@ var (
 			{
 				Name:     "library1",
 				Version:  "1.0.2",
-				Licenses: []string{detectlicense.GPL3.Name, detectlicense.BSD2.Name},
+				Licenses: []string{detectlicense.GPL3Only.Name, detectlicense.BSD2.Name},
 			},
 			{
 				Name:     "library2",
@@ -56,7 +56,7 @@ var (
 			{
 				Name:     "library2",
 				Version:  "3.1.2",
-				Licenses: []string{detectlicense.Apache2.Name, detectlicense.GPL3.Name},
+				Licenses: []string{detectlicense.Apache2.Name, detectlicense.GPL3Only.Name},
 			},
 		},
 		Licenses: map[string]string{},
@@ -68,6 +68,71 @@ var (
 				Name:     "library1",
 				Version:  "1.0.2",
 				Licenses: []string{detectlicense.PublicDomain.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	forbiddenLicensesOnly = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.AGPL1Only.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	unrestrictedLicensesOnly = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.MIT.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	licensesForAmbassadorServersOnly = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3Only.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	mixOfLicensesIncludingForbidden = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3Only.Name},
+			},
+			{
+				Name:     "library2",
+				Version:  "3.1.3",
+				Licenses: []string{detectlicense.MIT.Name},
+			},
+			{
+				Name:     "library3",
+				Version:  "1.3.5",
+				Licenses: []string{detectlicense.AGPL1Only.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	mixOfLicensesWithoutForbidden = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3Only.Name, detectlicense.MIT.Name},
 			},
 		},
 		Licenses: map[string]string{},
@@ -96,18 +161,18 @@ func TestLicenseListIsCorrect(t *testing.T) {
 			"A dependency with multiple licenses",
 			dependencyWithMultipleLicenses,
 			map[string]string{
-				detectlicense.GPL3.Name: detectlicense.GPL3.URL,
-				detectlicense.BSD2.Name: detectlicense.BSD2.URL,
+				detectlicense.GPL3Only.Name: detectlicense.GPL3Only.URL,
+				detectlicense.BSD2.Name:     detectlicense.BSD2.URL,
 			},
 		},
 		{
 			"Dependencies with overlapping licenses",
 			dependenciesWithOverlappingLicenses,
 			map[string]string{
-				detectlicense.GPL3.Name:    detectlicense.GPL3.URL,
-				detectlicense.BSD2.Name:    detectlicense.BSD2.URL,
-				detectlicense.Apache2.Name: detectlicense.Apache2.URL,
-				detectlicense.GPL3.Name:    detectlicense.GPL3.URL,
+				detectlicense.GPL3Only.Name: detectlicense.GPL3Only.URL,
+				detectlicense.BSD2.Name:     detectlicense.BSD2.URL,
+				detectlicense.Apache2.Name:  detectlicense.Apache2.URL,
+				detectlicense.GPL3Only.Name: detectlicense.GPL3Only.URL,
 			},
 		},
 		{
@@ -121,11 +186,97 @@ func TestLicenseListIsCorrect(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			// No licenses does not generate an error
 			err := testCase.dependencies.UpdateLicenseList()
 			require.NoError(t, err)
 
 			require.Equal(t, testCase.expectedLicenses, testCase.dependencies.Licenses)
+		})
+	}
+}
+
+func TestCheckLicensesValidatesAllowedLicenseCorrectly(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		dependencies    dependencies.DependencyInfo
+		allowedLicenses detectlicense.AllowedLicenseUse
+	}{
+		{
+			"Empty dependency list is always allowed",
+			emptyDependencies,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Unrestricted licenses are OK on Ambassador Labs servers",
+			unrestrictedLicensesOnly,
+			detectlicense.OnAmbassadorServers,
+		},
+		{
+			"Unrestricted licenses are OK everywhere",
+			unrestrictedLicensesOnly,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Restricted licenses are OK on Ambassador Labs servers",
+			licensesForAmbassadorServersOnly,
+			detectlicense.OnAmbassadorServers,
+		},
+		{
+			"Mix of licenses without forbidden is allowed on Ambassador Labs servers",
+			mixOfLicensesWithoutForbidden,
+			detectlicense.OnAmbassadorServers,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			err := testCase.dependencies.CheckLicenses(testCase.allowedLicenses)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCheckLicensesValidatesForbiddenLicensesCorrectly(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		dependencies    dependencies.DependencyInfo
+		allowedLicenses detectlicense.AllowedLicenseUse
+	}{
+		{
+			"It's not possible to allow the use of forbidden licenses by mistake",
+			unrestrictedLicensesOnly,
+			detectlicense.Forbidden,
+		},
+		{
+			"Forbidden licenses are not allowed on Ambassador Labs servers",
+			forbiddenLicensesOnly,
+			detectlicense.OnAmbassadorServers,
+		},
+		{
+			"Forbidden licenses are not allowed on customer servers",
+			forbiddenLicensesOnly,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Restricted licenses are not OK on customer servers",
+			licensesForAmbassadorServersOnly,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Mix of licenses including forbidden is rejected in Ambassador Labs servers",
+			mixOfLicensesIncludingForbidden,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Mix of licenses without forbidden is rejected on customer servers",
+			mixOfLicensesWithoutForbidden,
+			detectlicense.Unrestricted,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			err := testCase.dependencies.CheckLicenses(testCase.allowedLicenses)
+			require.Error(t, err)
 		})
 	}
 }

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -9,37 +9,68 @@ import (
 	"strings"
 )
 
+type AllowedLicenseUse int
+
+const (
+	Forbidden AllowedLicenseUse = iota
+	OnAmbassadorServers
+	Unrestricted
+)
+
 type License struct {
 	Name           string
-	NoticeFile     bool   // are NOTICE files "a thing" for this license?
-	WeakCopyleft   bool   // requires that library to be open-source
-	StrongCopyleft bool   // requires the resulting program to be open-source
-	URL            string // Location of the license description
+	NoticeFile     bool              // are NOTICE files "a thing" for this license?
+	WeakCopyleft   bool              // requires that library to be open-source
+	StrongCopyleft bool              // requires the resulting program to be open-source
+	URL            string            // Location of the license description
+	AllowedUse     AllowedLicenseUse // Where is this license allowed
 }
 
 //nolint:gochecknoglobals // Would be 'const'.
 var (
-	Proprietary = License{Name: "proprietary"}
-
-	PublicDomain = License{Name: "Public domain"}
-
-	Apache2  = License{Name: "Apache License 2.0", NoticeFile: true, URL: "https://opensource.org/licenses/Apache-2.0"}
-	BSD1     = License{Name: "1-clause BSD license", URL: "https://opensource.org/licenses/BSD-1-Clause"}
-	BSD2     = License{Name: "2-clause BSD license", URL: "https://opensource.org/licenses/BSD-2-Clause"}
-	BSD3     = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause"}
+	Apache2 = License{Name: "Apache License 2.0", NoticeFile: true,
+		URL: "https://opensource.org/licenses/Apache-2.0", AllowedUse: Unrestricted}
+	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", AllowedUse: Forbidden}
+	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", AllowedUse: Forbidden}
+	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", AllowedUse: Forbidden}
+	AGPL3OrLater = License{Name: "GNU Affero General Public License v3.0 or later", AllowedUse: Forbidden}
+	BSD1         = License{Name: "1-clause BSD license", URL: "https://opensource.org/licenses/BSD-1-Clause",
+		AllowedUse: Unrestricted}
+	BSD2 = License{Name: "2-clause BSD license", URL: "https://opensource.org/licenses/BSD-2-Clause",
+		AllowedUse: Unrestricted}
+	BSD3 = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause",
+		AllowedUse: Unrestricted}
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
-		StrongCopyleft: true, URL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode"}
-	GPL3 = License{Name: "GNU General Public License Version 3", StrongCopyleft: true,
-		URL: "https://opensource.org/licenses/GPL-3.0"}
-	ISC           = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC"}
+		StrongCopyleft: true, URL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode", AllowedUse: Unrestricted}
+	GPL1Only    = License{Name: "GNU General Public License v1.0 only", AllowedUse: OnAmbassadorServers}
+	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later", AllowedUse: OnAmbassadorServers}
+	GPL2Only    = License{Name: "GNU General Public License v2.0 only", AllowedUse: OnAmbassadorServers}
+	GPL2OrLater = License{Name: "GNU General Public License v2.0 or later", AllowedUse: OnAmbassadorServers}
+	GPL3Only    = License{Name: "GNU General Public License v3.0 only", StrongCopyleft: true,
+		URL: "https://opensource.org/licenses/GPL-3.0", AllowedUse: OnAmbassadorServers}
+	GPL3OrLater = License{Name: "GNU General Public License v3.0 or later", AllowedUse: OnAmbassadorServers}
+	ISC         = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC", AllowedUse: Unrestricted}
+	LGPL2Only   = License{Name: "GNU Library General Public License v2 only", WeakCopyleft: true,
+		AllowedUse: OnAmbassadorServers}
+	LGPL2OrLater = License{Name: "GNU Library General Public License v2 or later", WeakCopyleft: true,
+		AllowedUse: OnAmbassadorServers}
+	LGPL21Only = License{Name: "GNU Lesser General Public License v2.1 only", WeakCopyleft: true,
+		AllowedUse: OnAmbassadorServers}
 	LGPL21OrLater = License{Name: "GNU Lesser General Public License v2.1 or later", WeakCopyleft: true,
-		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html"}
-	MIT  = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT"}
+		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html", AllowedUse: OnAmbassadorServers}
+	LGPL3Only = License{Name: "GNU Lesser General Public License v3.0 only", WeakCopyleft: true,
+		AllowedUse: OnAmbassadorServers}
+	LGPL3OrLater = License{Name: "GNU Lesser General Public License v3.0 or later", WeakCopyleft: true,
+		AllowedUse: OnAmbassadorServers}
+	MIT  = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT", AllowedUse: Unrestricted}
 	MPL2 = License{Name: "Mozilla Public License 2.0", NoticeFile: true,
-		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0"}
-	PSF         = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html"}
+		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", AllowedUse: Unrestricted}
+	Proprietary  = License{Name: "proprietary"}
+	PublicDomain = License{Name: "Public domain", AllowedUse: Unrestricted}
+	PSF          = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html",
+		AllowedUse: Unrestricted}
 	Unicode2015 = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
-		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html"}
+		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", AllowedUse: Unrestricted}
 )
 
 // https://spdx.org/licenses/
@@ -51,13 +82,27 @@ var (
 
 	SpdxIdentifiers = map[string]License{
 		"Apache-2.0":        Apache2,
+		"AGPL-1.0-only":     AGPL1Only,
+		"AGPL-1.0-or-later": AGPL1OrLater,
+		"AGPL-3.0-only":     AGPL3Only,
+		"AGPL-3.0-or-later": AGPL3OrLater,
 		"BSD-1-Clause":      BSD1,
 		"BSD-2-Clause":      BSD2,
 		"BSD-3-Clause":      BSD3,
 		"CC-BY-SA-4.0":      CcBySa40,
-		"GPL-3.0-only":      GPL3,
+		"GPL-1.0-only":      GPL1Only,
+		"GPL-1.0-or-later":  GPL1OrLater,
+		"GPL-2.0-only":      GPL2Only,
+		"GPL-2.0-or-later":  GPL2OrLater,
+		"GPL-3.0-only":      GPL3Only,
+		"GPL-3.0-or-later":  GPL3OrLater,
 		"ISC":               ISC,
+		"LGPL-2.0-only":     LGPL2Only,
+		"LGPL-2.0-or-later": LGPL2OrLater,
+		"LGPL-2.1-only":     LGPL21Only,
 		"LGPL-2.1-or-later": LGPL21OrLater,
+		"LGPL-3.0-only":     LGPL3Only,
+		"LGPL-3.0-or-later": LGPL3OrLater,
 		"MIT":               MIT,
 		"MPL-2.0":           MPL2,
 		"PSF-2.0":           PSF,


### PR DESCRIPTION
This PR contains changes to validate license usage according to the business logic described  [here](https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157)

`go-mkopensource` will take a new parameter that indicates if the application being analyzed is used in Ambassador Labs servers or on customer servers

In addition, there is logic to prevent the use of AGPL-like licenses everywhere.

After talking to Luke, the `proprietary` license type is not supposed to be allowed on any dependency but on Ambassador owned software. For now, I've just changed the logic to fail all the time if there is a dependency with proprietary licences and logic will be cleaned up later (or removed completely) after understanding properly how should we identify use of proprietary licenses.