### PR TITLE
Allow checking if dependencies of an application use a forbidden license

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There are two modes of operation:
     both the `OPENSOURCE.md` file that `--output-format=txt` generates
     (plus a footer reading "The appropriate license notices and source
     code are in correspondingly named directories."), and a directory
-    for each dependency, containing any nescessary license notices and
+    for each dependency, containing any necessary license notices and
     source code.
 
 Many licenses require the author to be credited, the full license text
@@ -93,16 +93,26 @@ directing the output to).
 ### Output type
 
 Parameter --output-type controls for output format.
-When parameter is not provided in the command line or value is incorrect, `--output-type` is set to `markdown`
+When parameter is not provided in the command line or value is incorrect,
+`--output-type` is set to `markdown`
 This parameter only applies when `--ouput-format` is `txt`
 
 #### `--output-type=markdown`
 
-Program outputs dependency information in markdown format
+Program outputs dependency information in Markdown format
 
 #### `--output-type=json`
 
 Program outputs dependency information in json format
+
+### Application type
+
+Parameter `--application-type` controls the types of licenses that are 
+allowed. Logic is documented in [Notion](https://www.notion.so/datawire/1-Automate-License-Scan-and-Information-Files-31f4cd0f58f645f0afb922cfd710df81) 
+
+This parameter can take two values:
+- Internal: Applies validation for applications that run on customer infrastructure
+- External: Applies validation for applications that run on Ambassador Labs infrastructure
 
 ## Using as a library
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ directing the output to).
 
 ### Output type
 
-Parameter --output-type controls for output format.
-When parameter is not provided in the command line or value is incorrect,
-`--output-type` is set to `markdown`
+Parameter --output-type controls for output format.  
+When parameter is not provided in the command line or value is 
+incorrect, `--output-type` is set to `markdown`.
+
 This parameter only applies when `--ouput-format` is `txt`
 
 #### `--output-type=markdown`
@@ -110,9 +111,15 @@ Program outputs dependency information in json format
 Parameter `--application-type` controls the types of licenses that are 
 allowed. Logic is documented in [Notion](https://www.notion.so/datawire/1-Automate-License-Scan-and-Information-Files-31f4cd0f58f645f0afb922cfd710df81) 
 
-This parameter can take two values:
-- Internal: Applies validation for applications that run on customer infrastructure
-- External: Applies validation for applications that run on Ambassador Labs infrastructure
+#### `--application-type=internal`
+
+Use this option with applications that run on customer infrastructure. 
+This is the default.
+
+#### `--application-type=external`
+
+Use this option with applications that run on Ambassador Labs 
+infrastructure.
 
 ## Using as a library
 

--- a/dependency.go
+++ b/dependency.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"github.com/datawire/go-mkopensource/pkg/dependencies"
+	"github.com/datawire/go-mkopensource/pkg/detectlicense"
+	"github.com/datawire/go-mkopensource/pkg/golist"
+	"sort"
+)
+
+func GenerateDependencyList(modNames []string, modLicenses map[string]map[detectlicense.License]struct{},
+	modInfos map[string]*golist.Module, goVersion string, licenseUsage detectlicense.AllowedLicenseUse) (dependencies.DependencyInfo, error) {
+	dependencyList := dependencies.NewDependencyInfo()
+
+	for _, modKey := range modNames {
+		ambassadorProprietary := isAmbassadorProprietary(modLicenses[modKey])
+		if ambassadorProprietary {
+			continue
+		}
+
+		modVal := modInfos[modKey]
+
+		dependencyDetails := dependencies.Dependency{
+			Name:     getDependencyName(modVal),
+			Version:  getDependencyVersion(modVal, goVersion),
+			Licenses: []string{},
+		}
+
+		for license := range modLicenses[modKey] {
+			dependencyDetails.Licenses = append(dependencyDetails.Licenses, license.Name)
+		}
+		sort.Strings(dependencyDetails.Licenses)
+
+		dependencyList.Dependencies = append(dependencyList.Dependencies, dependencyDetails)
+	}
+
+	if err := dependencyList.CheckLicenses(licenseUsage); err != nil {
+		return dependencyList, fmt.Errorf("License validation failed: %v\n", err)
+	}
+
+	if err := dependencyList.UpdateLicenseList(); err != nil {
+		return dependencyList, fmt.Errorf("Could not generate list of license URLs: %v\n", err)
+	}
+
+	return dependencyList, nil
+}
+
+func getDependencyName(modVal *golist.Module) string {
+	if modVal == nil {
+		return "the Go language standard library (\"std\")"
+	}
+
+	if modVal.Replace != nil && modVal.Replace.Version != "" && modVal.Replace.Path != modVal.Path {
+		return fmt.Sprintf("%s (modified from %s)", modVal.Replace.Path, modVal.Path)
+	}
+
+	return modVal.Path
+}
+
+func getDependencyVersion(modVal *golist.Module, goVersion string) string {
+	if modVal == nil {
+		return goVersion
+	}
+
+	if modVal.Replace != nil {
+		if modVal.Replace.Version == "" {
+			return "(modified)"
+		} else {
+			return modVal.Replace.Version
+		}
+	}
+
+	return modVal.Version
+}

--- a/dependency_test.go
+++ b/dependency_test.go
@@ -1,0 +1,40 @@
+package main_test
+
+import (
+	"github.com/datawire/go-mkopensource"
+	. "github.com/datawire/go-mkopensource/pkg/detectlicense"
+	"github.com/datawire/go-mkopensource/pkg/golist"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+//nolint:gochecknoglobals // Can't be a constant
+var (
+	goVersion = "v1.17.3"
+	modNames  = []string{"github.com/josharian/intern"}
+	modInfos  = map[string]*golist.Module{
+		"github.com/josharian/intern": {
+			Path:    "github.com/josharian/intern",
+			Version: "1.2.3",
+		}}
+)
+
+func TestGenerateDependencyListWhenLicenseIsAllowed(t *testing.T) {
+	licenses := map[string]map[License]struct{}{modNames[0]: {BSD1: {}}}
+
+	_, err := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
+	require.NoError(t, err)
+
+	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, OnAmbassadorServers)
+	require.NoError(t, err)
+}
+
+func TestGenerateDependencyListWhenLicenseIsForbidden(t *testing.T) {
+	licenses := map[string]map[License]struct{}{modNames[0]: {AGPL1Only: {}}}
+
+	_, err := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
+	require.Error(t, err)
+
+	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, OnAmbassadorServers)
+	require.Error(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -33,8 +33,16 @@ type CLIArgs struct {
 }
 
 const (
+	// Type of output to generate
 	markdownOutputType = "markdown"
 	jsonOutputType     = "json"
+
+	// Validation to do on the licenses.
+	// The only validation for "internal" is to check chat forbidden licenses are not used
+	internalUsage = "internal"
+	// "external" applications have additional license requirements as documented in
+	//https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157
+	externalUsage = "external"
 )
 
 func parseArgs() (*CLIArgs, error) {
@@ -44,7 +52,12 @@ func parseArgs() (*CLIArgs, error) {
 	argparser.BoolVarP(&help, "help", "h", false, "Show this message")
 	argparser.StringVar(&args.OutputFormat, "output-format", "", "Output format ('tar' or 'txt')")
 	argparser.StringVar(&args.OutputName, "output-name", "", "Name of the root directory in the --output-format=tar tarball")
-	argparser.StringVar(&args.OutputType, "output-type", markdownOutputType, fmt.Sprintf("Format used when printing dependency information. One of: %s, %s", markdownOutputType, jsonOutputType))
+	argparser.StringVar(&args.OutputType, "output-type", markdownOutputType,
+		fmt.Sprintf("Format used when printing dependency information. One of: %s, %s", markdownOutputType, jsonOutputType))
+	argparser.StringVar(&args.OutputType, "application-type", externalUsage,
+		fmt.Sprintf("Where will the application run. One of: %s, %s\n"+
+			"Internal applications are run on Ambassador servers.\n"+
+			"External applications run on client-controlled infrastructure", internalUsage, externalUsage))
 	argparser.StringVar(&args.GoTarFilename, "gotar", "", "Tarball of the Go stdlib source code")
 	argparser.StringVar(&args.Package, "package", "", "The package(s) to report library usage for")
 	if err := argparser.Parse(os.Args[1:]); err != nil {

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -111,7 +111,7 @@ func (d *DependencyInfo) CheckLicenses(allowedLicenses detectlicense.AllowedLice
 			}
 
 			if license.AllowedUse < allowedLicenses {
-				return fmt.Errorf("license '%s' should not be used since it doesn't meet the useage requirements", license.Name)
+				return fmt.Errorf("license '%s' should not be used since it should not run on customer servers", license.Name)
 			}
 		}
 	}

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -3,39 +3,39 @@ package dependencies
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/datawire/go-mkopensource/pkg/detectlicense"
+	. "github.com/datawire/go-mkopensource/pkg/detectlicense"
 )
 
 //nolint:gochecknoglobals // Can't be a constant
-var licensesByName = map[string]detectlicense.License{
-	detectlicense.AmbassadorProprietary.Name: detectlicense.AmbassadorProprietary,
-	detectlicense.Apache2.Name:               detectlicense.Apache2,
-	detectlicense.AGPL1Only.Name:             detectlicense.AGPL1Only,
-	detectlicense.AGPL1OrLater.Name:          detectlicense.AGPL1OrLater,
-	detectlicense.AGPL3Only.Name:             detectlicense.AGPL3Only,
-	detectlicense.AGPL3OrLater.Name:          detectlicense.AGPL3OrLater,
-	detectlicense.BSD1.Name:                  detectlicense.BSD1,
-	detectlicense.BSD2.Name:                  detectlicense.BSD2,
-	detectlicense.BSD3.Name:                  detectlicense.BSD3,
-	detectlicense.CcBySa40.Name:              detectlicense.CcBySa40,
-	detectlicense.GPL1Only.Name:              detectlicense.GPL1Only,
-	detectlicense.GPL1OrLater.Name:           detectlicense.GPL1OrLater,
-	detectlicense.GPL2Only.Name:              detectlicense.GPL2Only,
-	detectlicense.GPL2OrLater.Name:           detectlicense.GPL2OrLater,
-	detectlicense.GPL3Only.Name:              detectlicense.GPL3Only,
-	detectlicense.GPL3OrLater.Name:           detectlicense.GPL3OrLater,
-	detectlicense.ISC.Name:                   detectlicense.ISC,
-	detectlicense.LGPL2Only.Name:             detectlicense.LGPL2Only,
-	detectlicense.LGPL2OrLater.Name:          detectlicense.LGPL2OrLater,
-	detectlicense.LGPL21Only.Name:            detectlicense.LGPL21Only,
-	detectlicense.LGPL21OrLater.Name:         detectlicense.LGPL21OrLater,
-	detectlicense.LGPL3Only.Name:             detectlicense.LGPL3Only,
-	detectlicense.LGPL3OrLater.Name:          detectlicense.LGPL3OrLater,
-	detectlicense.MIT.Name:                   detectlicense.MIT,
-	detectlicense.MPL2.Name:                  detectlicense.MPL2,
-	detectlicense.PSF.Name:                   detectlicense.PSF,
-	detectlicense.PublicDomain.Name:          detectlicense.PublicDomain,
-	detectlicense.Unicode2015.Name:           detectlicense.Unicode2015}
+var licensesByName = map[string]License{
+	AmbassadorProprietary.Name: AmbassadorProprietary,
+	Apache2.Name:               Apache2,
+	AGPL1Only.Name:             AGPL1Only,
+	AGPL1OrLater.Name:          AGPL1OrLater,
+	AGPL3Only.Name:             AGPL3Only,
+	AGPL3OrLater.Name:          AGPL3OrLater,
+	BSD1.Name:                  BSD1,
+	BSD2.Name:                  BSD2,
+	BSD3.Name:                  BSD3,
+	CcBySa40.Name:              CcBySa40,
+	GPL1Only.Name:              GPL1Only,
+	GPL1OrLater.Name:           GPL1OrLater,
+	GPL2Only.Name:              GPL2Only,
+	GPL2OrLater.Name:           GPL2OrLater,
+	GPL3Only.Name:              GPL3Only,
+	GPL3OrLater.Name:           GPL3OrLater,
+	ISC.Name:                   ISC,
+	LGPL2Only.Name:             LGPL2Only,
+	LGPL2OrLater.Name:          LGPL2OrLater,
+	LGPL21Only.Name:            LGPL21Only,
+	LGPL21OrLater.Name:         LGPL21OrLater,
+	LGPL3Only.Name:             LGPL3Only,
+	LGPL3OrLater.Name:          LGPL3OrLater,
+	MIT.Name:                   MIT,
+	MPL2.Name:                  MPL2,
+	PSF.Name:                   PSF,
+	PublicDomain.Name:          PublicDomain,
+	Unicode2015.Name:           Unicode2015}
 
 type DependencyInfo struct {
 	Dependencies []Dependency      `json:"dependencies"`
@@ -64,7 +64,7 @@ func (d *DependencyInfo) Unmarshal(data []byte) error {
 }
 
 func (d *DependencyInfo) UpdateLicenseList() error {
-	usedLicenses := map[string]detectlicense.License{}
+	usedLicenses := map[string]License{}
 
 	for _, dependency := range d.Dependencies {
 		for _, licenseName := range dependency.Licenses {
@@ -83,10 +83,10 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 	return nil
 }
 
-func getLicenseFromName(licenseName string) (detectlicense.License, error) {
+func getLicenseFromName(licenseName string) (License, error) {
 	license, ok := licensesByName[licenseName]
 	if !ok {
-		return detectlicense.License{}, fmt.Errorf("license details for '%s' are not known", licenseName)
+		return License{}, fmt.Errorf("license details for '%s' are not known", licenseName)
 	}
 	return license, nil
 }
@@ -94,8 +94,8 @@ func getLicenseFromName(licenseName string) (detectlicense.License, error) {
 // CheckLicenses checks that the licenses used by the dependencies are known and allowed to be used
 //in an application based on the buiness logic described here: https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157.
 //This function must be called after parsing of the licenses has been done.
-func (d *DependencyInfo) CheckLicenses(allowedLicenses detectlicense.AllowedLicenseUse) error {
-	if allowedLicenses == detectlicense.Forbidden {
+func (d *DependencyInfo) CheckLicenses(allowedLicenses AllowedLicenseUse) error {
+	if allowedLicenses == Forbidden {
 		return fmt.Errorf("forbidden licenses should not be used")
 	}
 
@@ -106,7 +106,7 @@ func (d *DependencyInfo) CheckLicenses(allowedLicenses detectlicense.AllowedLice
 				return err
 			}
 
-			if license.AllowedUse == detectlicense.Forbidden {
+			if license.AllowedUse == Forbidden {
 				return fmt.Errorf("license '%s' is forbidden", license.Name)
 			}
 

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -7,20 +7,34 @@ import (
 )
 
 //nolint:gochecknoglobals // Can't be a constant
-var knownLicenses = map[string]detectlicense.License{
+var licensesByName = map[string]detectlicense.License{
 	detectlicense.AmbassadorProprietary.Name: detectlicense.AmbassadorProprietary,
-	detectlicense.PublicDomain.Name:          detectlicense.PublicDomain,
 	detectlicense.Apache2.Name:               detectlicense.Apache2,
+	detectlicense.AGPL1Only.Name:             detectlicense.AGPL1Only,
+	detectlicense.AGPL1OrLater.Name:          detectlicense.AGPL1OrLater,
+	detectlicense.AGPL3Only.Name:             detectlicense.AGPL3Only,
+	detectlicense.AGPL3OrLater.Name:          detectlicense.AGPL3OrLater,
 	detectlicense.BSD1.Name:                  detectlicense.BSD1,
 	detectlicense.BSD2.Name:                  detectlicense.BSD2,
 	detectlicense.BSD3.Name:                  detectlicense.BSD3,
 	detectlicense.CcBySa40.Name:              detectlicense.CcBySa40,
-	detectlicense.GPL3.Name:                  detectlicense.GPL3,
+	detectlicense.GPL1Only.Name:              detectlicense.GPL1Only,
+	detectlicense.GPL1OrLater.Name:           detectlicense.GPL1OrLater,
+	detectlicense.GPL2Only.Name:              detectlicense.GPL2Only,
+	detectlicense.GPL2OrLater.Name:           detectlicense.GPL2OrLater,
+	detectlicense.GPL3Only.Name:              detectlicense.GPL3Only,
+	detectlicense.GPL3OrLater.Name:           detectlicense.GPL3OrLater,
 	detectlicense.ISC.Name:                   detectlicense.ISC,
+	detectlicense.LGPL2Only.Name:             detectlicense.LGPL2Only,
+	detectlicense.LGPL2OrLater.Name:          detectlicense.LGPL2OrLater,
+	detectlicense.LGPL21Only.Name:            detectlicense.LGPL21Only,
 	detectlicense.LGPL21OrLater.Name:         detectlicense.LGPL21OrLater,
+	detectlicense.LGPL3Only.Name:             detectlicense.LGPL3Only,
+	detectlicense.LGPL3OrLater.Name:          detectlicense.LGPL3OrLater,
 	detectlicense.MIT.Name:                   detectlicense.MIT,
 	detectlicense.MPL2.Name:                  detectlicense.MPL2,
 	detectlicense.PSF.Name:                   detectlicense.PSF,
+	detectlicense.PublicDomain.Name:          detectlicense.PublicDomain,
 	detectlicense.Unicode2015.Name:           detectlicense.Unicode2015}
 
 type DependencyInfo struct {
@@ -54,9 +68,9 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 
 	for _, dependency := range d.Dependencies {
 		for _, licenseName := range dependency.Licenses {
-			license, ok := knownLicenses[licenseName]
-			if !ok {
-				return fmt.Errorf("license details for '%s' are not known", licenseName)
+			license, err := getLicenseFromName(licenseName)
+			if err != nil {
+				return err
 			}
 			usedLicenses[license.Name] = license
 		}
@@ -66,5 +80,40 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 		d.Licenses[k] = v.URL
 	}
 
+	return nil
+}
+
+func getLicenseFromName(licenseName string) (detectlicense.License, error) {
+	license, ok := licensesByName[licenseName]
+	if !ok {
+		return detectlicense.License{}, fmt.Errorf("license details for '%s' are not known", licenseName)
+	}
+	return license, nil
+}
+
+// CheckLicenses checks that the licenses used by the dependencies are known and allowed to be used
+//in an application based on the buiness logic described here: https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157.
+//This function must be called after parsing of the licenses has been done.
+func (d *DependencyInfo) CheckLicenses(allowedLicenses detectlicense.AllowedLicenseUse) error {
+	if allowedLicenses == detectlicense.Forbidden {
+		return fmt.Errorf("forbidden licenses should not be used")
+	}
+
+	for _, dependency := range d.Dependencies {
+		for _, licenseName := range dependency.Licenses {
+			license, err := getLicenseFromName(licenseName)
+			if err != nil {
+				return err
+			}
+
+			if license.AllowedUse == detectlicense.Forbidden {
+				return fmt.Errorf("license '%s' is forbidden", license.Name)
+			}
+
+			if license.AllowedUse < allowedLicenses {
+				return fmt.Errorf("license '%s' should not be used since it doesn't meet the useage requirements", license.Name)
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/dependencies/dependencyinfo_test.go
+++ b/pkg/dependencies/dependencyinfo_test.go
@@ -35,7 +35,7 @@ var (
 			{
 				Name:     "library1",
 				Version:  "1.0.2",
-				Licenses: []string{detectlicense.GPL3.Name, detectlicense.BSD2.Name},
+				Licenses: []string{detectlicense.GPL3Only.Name, detectlicense.BSD2.Name},
 			},
 		},
 		Licenses: map[string]string{},
@@ -46,7 +46,7 @@ var (
 			{
 				Name:     "library1",
 				Version:  "1.0.2",
-				Licenses: []string{detectlicense.GPL3.Name, detectlicense.BSD2.Name},
+				Licenses: []string{detectlicense.GPL3Only.Name, detectlicense.BSD2.Name},
 			},
 			{
 				Name:     "library2",
@@ -56,7 +56,7 @@ var (
 			{
 				Name:     "library2",
 				Version:  "3.1.2",
-				Licenses: []string{detectlicense.Apache2.Name, detectlicense.GPL3.Name},
+				Licenses: []string{detectlicense.Apache2.Name, detectlicense.GPL3Only.Name},
 			},
 		},
 		Licenses: map[string]string{},
@@ -68,6 +68,71 @@ var (
 				Name:     "library1",
 				Version:  "1.0.2",
 				Licenses: []string{detectlicense.PublicDomain.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	forbiddenLicensesOnly = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.AGPL1Only.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	unrestrictedLicensesOnly = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.MIT.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	licensesForAmbassadorServersOnly = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3Only.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	mixOfLicensesIncludingForbidden = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3Only.Name},
+			},
+			{
+				Name:     "library2",
+				Version:  "3.1.3",
+				Licenses: []string{detectlicense.MIT.Name},
+			},
+			{
+				Name:     "library3",
+				Version:  "1.3.5",
+				Licenses: []string{detectlicense.AGPL1Only.Name},
+			},
+		},
+		Licenses: map[string]string{},
+	}
+
+	mixOfLicensesWithoutForbidden = dependencies.DependencyInfo{
+		Dependencies: []dependencies.Dependency{
+			{
+				Name:     "library1",
+				Version:  "1.0.2",
+				Licenses: []string{detectlicense.GPL3Only.Name, detectlicense.MIT.Name},
 			},
 		},
 		Licenses: map[string]string{},
@@ -96,18 +161,18 @@ func TestLicenseListIsCorrect(t *testing.T) {
 			"A dependency with multiple licenses",
 			dependencyWithMultipleLicenses,
 			map[string]string{
-				detectlicense.GPL3.Name: detectlicense.GPL3.URL,
-				detectlicense.BSD2.Name: detectlicense.BSD2.URL,
+				detectlicense.GPL3Only.Name: detectlicense.GPL3Only.URL,
+				detectlicense.BSD2.Name:     detectlicense.BSD2.URL,
 			},
 		},
 		{
 			"Dependencies with overlapping licenses",
 			dependenciesWithOverlappingLicenses,
 			map[string]string{
-				detectlicense.GPL3.Name:    detectlicense.GPL3.URL,
-				detectlicense.BSD2.Name:    detectlicense.BSD2.URL,
-				detectlicense.Apache2.Name: detectlicense.Apache2.URL,
-				detectlicense.GPL3.Name:    detectlicense.GPL3.URL,
+				detectlicense.GPL3Only.Name: detectlicense.GPL3Only.URL,
+				detectlicense.BSD2.Name:     detectlicense.BSD2.URL,
+				detectlicense.Apache2.Name:  detectlicense.Apache2.URL,
+				detectlicense.GPL3Only.Name: detectlicense.GPL3Only.URL,
 			},
 		},
 		{
@@ -121,11 +186,97 @@ func TestLicenseListIsCorrect(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			// No licenses does not generate an error
 			err := testCase.dependencies.UpdateLicenseList()
 			require.NoError(t, err)
 
 			require.Equal(t, testCase.expectedLicenses, testCase.dependencies.Licenses)
+		})
+	}
+}
+
+func TestCheckLicensesValidatesAllowedLicenseCorrectly(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		dependencies    dependencies.DependencyInfo
+		allowedLicenses detectlicense.AllowedLicenseUse
+	}{
+		{
+			"Empty dependency list is always allowed",
+			emptyDependencies,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Unrestricted licenses are OK on Ambassador Labs servers",
+			unrestrictedLicensesOnly,
+			detectlicense.OnAmbassadorServers,
+		},
+		{
+			"Unrestricted licenses are OK everywhere",
+			unrestrictedLicensesOnly,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Restricted licenses are OK on Ambassador Labs servers",
+			licensesForAmbassadorServersOnly,
+			detectlicense.OnAmbassadorServers,
+		},
+		{
+			"Mix of licenses without forbidden is allowed on Ambassador Labs servers",
+			mixOfLicensesWithoutForbidden,
+			detectlicense.OnAmbassadorServers,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			err := testCase.dependencies.CheckLicenses(testCase.allowedLicenses)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCheckLicensesValidatesForbiddenLicensesCorrectly(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		dependencies    dependencies.DependencyInfo
+		allowedLicenses detectlicense.AllowedLicenseUse
+	}{
+		{
+			"It's not possible to allow the use of forbidden licenses by mistake",
+			unrestrictedLicensesOnly,
+			detectlicense.Forbidden,
+		},
+		{
+			"Forbidden licenses are not allowed on Ambassador Labs servers",
+			forbiddenLicensesOnly,
+			detectlicense.OnAmbassadorServers,
+		},
+		{
+			"Forbidden licenses are not allowed on customer servers",
+			forbiddenLicensesOnly,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Restricted licenses are not OK on customer servers",
+			licensesForAmbassadorServersOnly,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Mix of licenses including forbidden is rejected in Ambassador Labs servers",
+			mixOfLicensesIncludingForbidden,
+			detectlicense.Unrestricted,
+		},
+		{
+			"Mix of licenses without forbidden is rejected on customer servers",
+			mixOfLicensesWithoutForbidden,
+			detectlicense.Unrestricted,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			err := testCase.dependencies.CheckLicenses(testCase.allowedLicenses)
+			require.Error(t, err)
 		})
 	}
 }

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -9,37 +9,68 @@ import (
 	"strings"
 )
 
+type AllowedLicenseUse int
+
+const (
+	Forbidden AllowedLicenseUse = iota
+	OnAmbassadorServers
+	Unrestricted
+)
+
 type License struct {
 	Name           string
-	NoticeFile     bool   // are NOTICE files "a thing" for this license?
-	WeakCopyleft   bool   // requires that library to be open-source
-	StrongCopyleft bool   // requires the resulting program to be open-source
-	URL            string // Location of the license description
+	NoticeFile     bool              // are NOTICE files "a thing" for this license?
+	WeakCopyleft   bool              // requires that library to be open-source
+	StrongCopyleft bool              // requires the resulting program to be open-source
+	URL            string            // Location of the license description
+	AllowedUse     AllowedLicenseUse // Where is this license allowed
 }
 
 //nolint:gochecknoglobals // Would be 'const'.
 var (
 	AmbassadorProprietary = License{Name: "proprietary Ambassador software"}
-
-	PublicDomain = License{Name: "Public domain"}
-
-	Apache2  = License{Name: "Apache License 2.0", NoticeFile: true, URL: "https://opensource.org/licenses/Apache-2.0"}
-	BSD1     = License{Name: "1-clause BSD license", URL: "https://opensource.org/licenses/BSD-1-Clause"}
-	BSD2     = License{Name: "2-clause BSD license", URL: "https://opensource.org/licenses/BSD-2-Clause"}
-	BSD3     = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause"}
+	Apache2               = License{Name: "Apache License 2.0", NoticeFile: true,
+		URL: "https://opensource.org/licenses/Apache-2.0", AllowedUse: Unrestricted}
+	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", AllowedUse: Forbidden}
+	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", AllowedUse: Forbidden}
+	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", AllowedUse: Forbidden}
+	AGPL3OrLater = License{Name: "GNU Affero General Public License v3.0 or later", AllowedUse: Forbidden}
+	BSD1         = License{Name: "1-clause BSD license", URL: "https://opensource.org/licenses/BSD-1-Clause",
+		AllowedUse: Unrestricted}
+	BSD2 = License{Name: "2-clause BSD license", URL: "https://opensource.org/licenses/BSD-2-Clause",
+		AllowedUse: Unrestricted}
+	BSD3 = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause",
+		AllowedUse: Unrestricted}
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
-		StrongCopyleft: true, URL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode"}
-	GPL3 = License{Name: "GNU General Public License Version 3", StrongCopyleft: true,
-		URL: "https://opensource.org/licenses/GPL-3.0"}
-	ISC           = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC"}
+		StrongCopyleft: true, URL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode", AllowedUse: Unrestricted}
+	GPL1Only    = License{Name: "GNU General Public License v1.0 only", AllowedUse: OnAmbassadorServers}
+	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later", AllowedUse: OnAmbassadorServers}
+	GPL2Only    = License{Name: "GNU General Public License v2.0 only", AllowedUse: OnAmbassadorServers}
+	GPL2OrLater = License{Name: "GNU General Public License v2.0 or later", AllowedUse: OnAmbassadorServers}
+	GPL3Only    = License{Name: "GNU General Public License v3.0 only", StrongCopyleft: true,
+		URL: "https://opensource.org/licenses/GPL-3.0", AllowedUse: OnAmbassadorServers}
+	GPL3OrLater = License{Name: "GNU General Public License v3.0 or later", AllowedUse: OnAmbassadorServers}
+	ISC         = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC", AllowedUse: Unrestricted}
+	LGPL2Only   = License{Name: "GNU Library General Public License v2 only", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	LGPL2OrLater = License{Name: "GNU Library General Public License v2 or later", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	LGPL21Only = License{Name: "GNU Lesser General Public License v2.1 only", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
 	LGPL21OrLater = License{Name: "GNU Lesser General Public License v2.1 or later", WeakCopyleft: true,
-		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html"}
-	MIT  = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT"}
+		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html", AllowedUse: Unrestricted}
+	LGPL3Only = License{Name: "GNU Lesser General Public License v3.0 only", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	LGPL3OrLater = License{Name: "GNU Lesser General Public License v3.0 or later", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	MIT  = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT", AllowedUse: Unrestricted}
 	MPL2 = License{Name: "Mozilla Public License 2.0", NoticeFile: true,
-		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0"}
-	PSF         = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html"}
-	Unicode2015 = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
-		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html"}
+		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", AllowedUse: Unrestricted}
+	PSF = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html",
+		AllowedUse: Unrestricted}
+	PublicDomain = License{Name: "Public domain"}
+	Unicode2015  = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
+		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", AllowedUse: Unrestricted}
 )
 
 // https://spdx.org/licenses/
@@ -51,13 +82,27 @@ var (
 
 	SpdxIdentifiers = map[string]License{
 		"Apache-2.0":        Apache2,
+		"AGPL-1.0-only":     AGPL1Only,
+		"AGPL-1.0-or-later": AGPL1OrLater,
+		"AGPL-3.0-only":     AGPL3Only,
+		"AGPL-3.0-or-later": AGPL3OrLater,
 		"BSD-1-Clause":      BSD1,
 		"BSD-2-Clause":      BSD2,
 		"BSD-3-Clause":      BSD3,
 		"CC-BY-SA-4.0":      CcBySa40,
-		"GPL-3.0-only":      GPL3,
+		"GPL-1.0-only":      GPL1Only,
+		"GPL-1.0-or-later":  GPL1OrLater,
+		"GPL-2.0-only":      GPL2Only,
+		"GPL-2.0-or-later":  GPL2OrLater,
+		"GPL-3.0-only":      GPL3Only,
+		"GPL-3.0-or-later":  GPL3OrLater,
 		"ISC":               ISC,
+		"LGPL-2.0-only":     LGPL2Only,
+		"LGPL-2.0-or-later": LGPL2OrLater,
+		"LGPL-2.1-only":     LGPL21Only,
 		"LGPL-2.1-or-later": LGPL21OrLater,
+		"LGPL-3.0-only":     LGPL3Only,
+		"LGPL-3.0-or-later": LGPL3OrLater,
 		"MIT":               MIT,
 		"MPL-2.0":           MPL2,
 		"PSF-2.0":           PSF,


### PR DESCRIPTION
This PR implements validations based on this [document](https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157)

There is a command line option `--application-type` that can be:
`external`: For applications that run on customer servers
`internal`: For applications that run on Ambassador servers

This flag control what validation is applied when checking licenses.

License validation code has been implemented as a package that can be reused in other applications.