### PR TITLE
bypass ambassador LICENSES.md

### DIFF
--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -147,6 +147,9 @@ loop:
 		case "github.com/telepresenceio/telepresence/v2/LICENSES.md":
 			// Licenses for telepresence are in LICENSE and not in LICENSES.md
 			continue loop
+		case "github.com/datawire/ambassador/v2/LICENSES.md":
+			// Licenses for ambassador are in LICENSE and not in LICENSES.md
+			continue loop
 		}
 
 		name := filepath.Base(filename)


### PR DESCRIPTION
Similarly to telepresence, edge-stack contains a LICENSES.md file with other projects licenses in it. This PR contains code to ignore it.

Signed-off-by: Aidan Hahn <aidanhahn@datawire.io>