### PR TITLE
Add new license types

### DIFF
--- a/build-aux/docker/customLicenseFormat.json
+++ b/build-aux/docker/customLicenseFormat.json
@@ -4,5 +4,7 @@
   "description": "",
   "licenseFile": "",
   "licenseText": "",
-  "licenseModified": ""
+  "licenseModified": "",
+  "repository": "",
+  "url": ""
 }

--- a/cmd/go-mkopensource/main.go
+++ b/cmd/go-mkopensource/main.go
@@ -283,11 +283,19 @@ func Main(args *CLIArgs) error {
 	for pkgName := range pkgFiles {
 		pkgNames = append(pkgNames, pkgName)
 	}
+
+	pkgVersions := map[string]string{}
+	for _, pkg := range listPkgs {
+		if pkg.Module != nil {
+			pkgVersions[pkg.ImportPath] = pkg.Module.Version
+		}
+	}
+
 	sort.Strings(pkgNames)
 	pkgLicenses := make(map[string]map[detectlicense.License]struct{})
 	licErrs := []error(nil)
 	for _, pkgName := range pkgNames {
-		pkgLicenses[pkgName], err = detectlicense.DetectLicenses(pkgName, pkgFiles[pkgName])
+		pkgLicenses[pkgName], err = detectlicense.DetectLicenses(pkgName, pkgVersions[pkgName], pkgFiles[pkgName])
 		if err == nil && licenseIsStrongCopyleft(pkgLicenses[pkgName]) {
 			err = fmt.Errorf("has an unacceptable license for use by Ambassador Labs (%s)",
 				licenseString(pkgLicenses[pkgName]))

--- a/cmd/go-mkopensource/main_test.go
+++ b/cmd/go-mkopensource/main_test.go
@@ -192,6 +192,16 @@ func TestErrorScenarios(t *testing.T) {
 			packagesFlag:   "mod",
 			outputTypeFlag: "full",
 		},
+		{
+			testData:       "testdata/07-forbidden-license",
+			packagesFlag:   "mod",
+			outputTypeFlag: "full",
+		},
+		{
+			testData:       "testdata/08-allowed-for-internal-use-only",
+			packagesFlag:   "mod",
+			outputTypeFlag: "full",
+		},
 	}
 
 	workingDir := getWorkingDir(t)
@@ -207,16 +217,17 @@ func TestErrorScenarios(t *testing.T) {
 			expectedError := getFileContents(t, "expected_err.txt")
 
 			actErr := main.Main(&main.CLIArgs{
-				OutputFormat:  "txt",
-				GoTarFilename: filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
-				Package:       testCase.packagesFlag,
-				OutputType:    testCase.outputTypeFlag,
+				OutputFormat:    "txt",
+				GoTarFilename:   filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
+				Package:         testCase.packagesFlag,
+				OutputType:      testCase.outputTypeFlag,
+				ApplicationType: "external",
 			})
 
 			if assert.Error(t, actErr) {
 				// Use this instead of assert.EqualError so that we diff
 				// output, which is helpful for long strings.
-				assert.Equal(t, strings.TrimSpace(string(expectedError)), actErr.Error())
+				assert.Equal(t, strings.TrimSpace(string(expectedError)), strings.TrimSpace(actErr.Error()))
 			}
 		})
 	}
@@ -274,7 +285,7 @@ func TestTarOutput(t *testing.T) {
 				if assert.Error(t, actErr) {
 					// Use this instead of assert.EqualError so that we diff
 					// output, which is helpful for long strings.
-					assert.Equal(t, strings.TrimSpace(string(expectedError)), actErr.Error())
+					assert.Equal(t, strings.TrimSpace(string(expectedError)), strings.TrimSpace(actErr.Error()))
 				}
 			}
 		})

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/agpl/agpl.go
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/agpl/agpl.go
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package agpl

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/agpl/go.mod
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/agpl/go.mod
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+module example.com/agpl
+
+go 1.17

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
@@ -1,0 +1,1 @@
+License validation failed: license 'GNU Affero General Public License v3.0 or later' is forbidden

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/go.mod
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/go.mod
@@ -1,0 +1,11 @@
+module testmod
+
+go 1.17
+
+require (
+	example.com/agpl v0.0.0-00010101000000-000000000000
+)
+
+replace (
+	example.com/agpl => ./agpl
+)

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/go.sum
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/go.sum
@@ -1,0 +1,2 @@
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/main.go
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	_ "example.com/agpl"
+)
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
@@ -1,0 +1,1 @@
+License validation failed: license 'GNU General Public License v1.0 or later' should not be used since it should not run on customer servers

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/go.mod
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/go.mod
@@ -1,0 +1,11 @@
+module testmod
+
+go 1.17
+
+require (
+	example.com/gpl v0.0.0-00010101000000-000000000000
+)
+
+replace (
+	example.com/gpl => ./gpl
+)

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/go.sum
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/go.sum
@@ -1,0 +1,2 @@
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/gpl/go.mod
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/gpl/go.mod
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-1.0-or-later
+
+module example.com/gpl
+
+go 1.17

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/gpl/gpl.go
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/gpl/gpl.go
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-1.0-or-later
+
+package gpl

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/main.go
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	_ "example.com/gpl"
+)
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/cmd/js-mkopensource/dependency/dependency.go
+++ b/cmd/js-mkopensource/dependency/dependency.go
@@ -109,7 +109,7 @@ func getDependencyLicenses(dependencyId string, nodeDependency nodeDependency) (
 			"Dependecy URL: %s\n"+
 			"Licenses: %s\n"+
 			"License text:\n%#v\n", spdxId, nodeDependency.Name, nodeDependency.Version,
-			nodeDependency.URL, nodeDependency.Licenses, nodeDependency.LicenseText)
+			nodeDependency.Repository, nodeDependency.Licenses, nodeDependency.LicenseText)
 	}
 
 	sort.Strings(allLicenses)

--- a/cmd/js-mkopensource/dependency/hardcodeddependencies.go
+++ b/cmd/js-mkopensource/dependency/hardcodeddependencies.go
@@ -1,10 +1,17 @@
 package dependency
 
-import "github.com/datawire/go-mkopensource/pkg/detectlicense"
+import . "github.com/datawire/go-mkopensource/pkg/detectlicense"
 
 //nolint:gochecknoglobals // Would be 'const'.
 var hardcodedDependencies = map[string][]string{
-	"cyclist@0.2.2": {detectlicense.MIT.Name},
-	"indexof@0.0.1": {detectlicense.MIT.Name},
-	"pako@1.0.10":   {detectlicense.MIT.Name},
+	"cyclist@0.2.2":                {MIT.Name},
+	"doctrine@1.5.0":               {BSD2.Name, Apache2.Name},
+	"emitter-component@1.1.1":      {MIT.Name},
+	"flexboxgrid@6.3.1":            {Apache2.Name},
+	"indexof@0.0.1":                {MIT.Name},
+	"intro.js@4.1.0":               {AGPL3OrLater.Name},
+	"node-forge@0.10.0":            {BSD3.Name},
+	"pako@1.0.10":                  {MIT.Name},
+	"regenerator-transform@0.10.1": {BSD2.Name},
+	"regjsparser@0.1.5":            {BSD2.Name},
 }

--- a/cmd/py-mkopensource/testdata/successful-generation/expected_json.json
+++ b/cmd/py-mkopensource/testdata/successful-generation/expected_json.json
@@ -36,7 +36,7 @@
     "2-clause BSD license": "https://opensource.org/licenses/BSD-2-Clause",
     "3-clause BSD license": "https://opensource.org/licenses/BSD-3-Clause",
     "Apache License 2.0": "https://opensource.org/licenses/Apache-2.0",
-    "GNU General Public License v3.0 or later": "",
+    "GNU General Public License v3.0 or later": "https://spdx.org/licenses/GPL-3.0-or-later.html",
     "Public domain": "",
     "Python Software Foundation license": "https://spdx.org/licenses/PSF-2.0.html"
   }

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -9,7 +9,9 @@ import (
 //nolint:gochecknoglobals // Can't be a constant
 var licensesByName = map[string]License{
 	AmbassadorProprietary.Name: AmbassadorProprietary,
+	ZeroBSD.Name:               ZeroBSD,
 	Apache2.Name:               Apache2,
+	AFL21.Name:                 AFL21,
 	AGPL1Only.Name:             AGPL1Only,
 	AGPL1OrLater.Name:          AGPL1OrLater,
 	AGPL3Only.Name:             AGPL3Only,
@@ -17,7 +19,11 @@ var licensesByName = map[string]License{
 	BSD1.Name:                  BSD1,
 	BSD2.Name:                  BSD2,
 	BSD3.Name:                  BSD3,
+	Cc010.Name:                 Cc010,
+	CcBy30.Name:                CcBy30,
+	CcBy40.Name:                CcBy40,
 	CcBySa40.Name:              CcBySa40,
+	EPL10.Name:                 EPL10,
 	GPL1Only.Name:              GPL1Only,
 	GPL1OrLater.Name:           GPL1OrLater,
 	GPL2Only.Name:              GPL2Only,
@@ -32,10 +38,17 @@ var licensesByName = map[string]License{
 	LGPL3Only.Name:             LGPL3Only,
 	LGPL3OrLater.Name:          LGPL3OrLater,
 	MIT.Name:                   MIT,
+	MPL11.Name:                 MPL11,
 	MPL2.Name:                  MPL2,
+	ODCBy10.Name:               ODCBy10,
+	OFL11.Name:                 OFL11,
 	PSF.Name:                   PSF,
+	Python20.Name:              Python20,
 	PublicDomain.Name:          PublicDomain,
-	Unicode2015.Name:           Unicode2015}
+	Unicode2015.Name:           Unicode2015,
+	Unlicense.Name:             Unlicense,
+	WTFPL.Name:                 WTFPL,
+}
 
 type DependencyInfo struct {
 	Dependencies []Dependency      `json:"dependencies"`

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -119,11 +119,20 @@ func expectsNotice(licenses map[License]struct{}) bool {
 	return false
 }
 
-func DetectLicenses(packageName string, files map[string][]byte) (map[License]struct{}, error) {
-	if strings.HasPrefix(packageName, "github.com/datawire/telepresence2-proprietary/") {
+func DetectLicenses(packageName string, packageVersion string, files map[string][]byte) (map[License]struct{}, error) {
+
+	if isAmbassadorProprietarySoftware(packageName) {
 		// Ambassador's proprietary software has a proprietary license
 		softwareLicenses := map[License]struct{}{AmbassadorProprietary: {}}
 		return softwareLicenses, nil
+	}
+
+	if knownDependencies, isKnown := knownDependencies(packageName, packageVersion); isKnown {
+		licenses := map[License]struct{}{}
+		for _, license := range knownDependencies {
+			licenses[license] = struct{}{}
+		}
+		return licenses, nil
 	}
 
 	licenses := make(map[License][]string)

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -29,8 +29,11 @@ type License struct {
 //nolint:gochecknoglobals // Would be 'const'.
 var (
 	AmbassadorProprietary = License{Name: "proprietary Ambassador software"}
-	Apache2               = License{Name: "Apache License 2.0", NoticeFile: true,
+	ZeroBSD               = License{Name: "BSD Zero Clause License",
+		URL: "https://spdx.org/licenses/0BSD.html", AllowedUse: Unrestricted}
+	Apache2 = License{Name: "Apache License 2.0", NoticeFile: true,
 		URL: "https://opensource.org/licenses/Apache-2.0", AllowedUse: Unrestricted}
+	AFL21        = License{Name: "Academic Free License v2.1", URL: "https://spdx.org/licenses/AFL-2.1.html", AllowedUse: Forbidden}
 	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", AllowedUse: Forbidden}
 	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", AllowedUse: Forbidden}
 	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", AllowedUse: Forbidden}
@@ -41,17 +44,30 @@ var (
 		AllowedUse: Unrestricted}
 	BSD3 = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause",
 		AllowedUse: Unrestricted}
+	CcBy30 = License{Name: "Creative Commons Attribution 3.0 Unported",
+		URL: "https://spdx.org/licenses/CC-BY-3.0.html", AllowedUse: OnAmbassadorServers}
+	CcBy40 = License{Name: "Creative Commons Attribution 4.0 International",
+		URL: "https://spdx.org/licenses/CC-BY-4.0.html", AllowedUse: OnAmbassadorServers}
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
-		StrongCopyleft: true, URL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode", AllowedUse: Unrestricted}
-	GPL1Only    = License{Name: "GNU General Public License v1.0 only", AllowedUse: OnAmbassadorServers}
-	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later", AllowedUse: OnAmbassadorServers}
-	GPL2Only    = License{Name: "GNU General Public License v2.0 only", AllowedUse: OnAmbassadorServers}
-	GPL2OrLater = License{Name: "GNU General Public License v2.0 or later", AllowedUse: OnAmbassadorServers}
-	GPL3Only    = License{Name: "GNU General Public License v3.0 only", StrongCopyleft: true,
-		URL: "https://opensource.org/licenses/GPL-3.0", AllowedUse: OnAmbassadorServers}
-	GPL3OrLater = License{Name: "GNU General Public License v3.0 or later", AllowedUse: OnAmbassadorServers}
-	ISC         = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC", AllowedUse: Unrestricted}
-	LGPL2Only   = License{Name: "GNU Library General Public License v2 only", WeakCopyleft: true,
+		StrongCopyleft: true, URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html", AllowedUse: OnAmbassadorServers}
+	Cc010 = License{Name: "Creative Commons Zero v1.0 Universal",
+		URL: "https://spdx.org/licenses/CC0-1.0.html", AllowedUse: Forbidden}
+	EPL10 = License{Name: "Eclipse Public License 1.0", URL: "https://spdx.org/licenses/EPL-1.0.html",
+		AllowedUse: Forbidden}
+	GPL1Only = License{Name: "GNU General Public License v1.0 only",
+		URL: "https://spdx.org/licenses/GPL-1.0-only.html", AllowedUse: OnAmbassadorServers}
+	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later",
+		URL: "https://spdx.org/licenses/GPL-1.0-or-later.html", AllowedUse: OnAmbassadorServers}
+	GPL2Only = License{Name: "GNU General Public License v2.0 only",
+		URL: "https://spdx.org/licenses/GPL-2.0-only.html", AllowedUse: OnAmbassadorServers}
+	GPL2OrLater = License{Name: "GNU General Public License v2.0 or later",
+		URL: "https://spdx.org/licenses/GPL-2.0-or-later.html", AllowedUse: OnAmbassadorServers}
+	GPL3Only = License{Name: "GNU General Public License v3.0 only", StrongCopyleft: true,
+		URL: "https://spdx.org/licenses/GPL-3.0.html", AllowedUse: OnAmbassadorServers}
+	GPL3OrLater = License{Name: "GNU General Public License v3.0 or later",
+		URL: "https://spdx.org/licenses/GPL-3.0-or-later.html", AllowedUse: OnAmbassadorServers}
+	ISC       = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC", AllowedUse: Unrestricted}
+	LGPL2Only = License{Name: "GNU Library General Public License v2 only", WeakCopyleft: true,
 		AllowedUse: Unrestricted}
 	LGPL2OrLater = License{Name: "GNU Library General Public License v2 or later", WeakCopyleft: true,
 		AllowedUse: Unrestricted}
@@ -63,14 +79,26 @@ var (
 		AllowedUse: Unrestricted}
 	LGPL3OrLater = License{Name: "GNU Lesser General Public License v3.0 or later", WeakCopyleft: true,
 		AllowedUse: Unrestricted}
-	MIT  = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT", AllowedUse: Unrestricted}
+	MIT   = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT", AllowedUse: Unrestricted}
+	MPL11 = License{Name: "Mozilla Public License 1.1", NoticeFile: true,
+		WeakCopyleft: true, URL: "https://spdx.org/licenses/MPL-1.1.html", AllowedUse: Unrestricted}
 	MPL2 = License{Name: "Mozilla Public License 2.0", NoticeFile: true,
 		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", AllowedUse: Unrestricted}
+	ODCBy10 = License{Name: "Open Data Commons Attribution License v1.0", URL: "https://spdx.org/licenses/ODC-By-1.0.html",
+		AllowedUse: Forbidden}
+	OFL11 = License{Name: "SIL Open Font License 1.1", URL: "https://spdx.org/licenses/OFL-1.1.html",
+		AllowedUse: Forbidden}
+	Python20 = License{Name: "Python License 2.0", URL: "https://spdx.org/licenses/Python-2.0.html",
+		AllowedUse: Unrestricted}
 	PSF = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html",
 		AllowedUse: Unrestricted}
 	PublicDomain = License{Name: "Public domain"}
 	Unicode2015  = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
 		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", AllowedUse: Unrestricted}
+	Unlicense = License{Name: "The Unlicense",
+		URL: "https://spdx.org/licenses/Unlicense.html", AllowedUse: Forbidden}
+	WTFPL = License{Name: "Do What The F*ck You Want To Public License",
+		URL: "https://spdx.org/licenses/WTFPL.html", AllowedUse: Forbidden}
 )
 
 // https://spdx.org/licenses/
@@ -81,7 +109,9 @@ var (
 	spdxTag = []byte("SPDX-License" + "-Identifier:")
 
 	SpdxIdentifiers = map[string]License{
+		"0BSD":              ZeroBSD,
 		"Apache-2.0":        Apache2,
+		"AFL-2.1":           AFL21,
 		"AGPL-1.0-only":     AGPL1Only,
 		"AGPL-1.0-or-later": AGPL1OrLater,
 		"AGPL-3.0-only":     AGPL3Only,
@@ -89,7 +119,11 @@ var (
 		"BSD-1-Clause":      BSD1,
 		"BSD-2-Clause":      BSD2,
 		"BSD-3-Clause":      BSD3,
+		"CC-BY-3.0":         CcBy30,
+		"CC-BY-4.0":         CcBy40,
 		"CC-BY-SA-4.0":      CcBySa40,
+		"CC0-1.0":           Cc010,
+		"EPL-1.0":           EPL10,
 		"GPL-1.0-only":      GPL1Only,
 		"GPL-1.0-or-later":  GPL1OrLater,
 		"GPL-2.0-only":      GPL2Only,
@@ -104,9 +138,15 @@ var (
 		"LGPL-3.0-only":     LGPL3Only,
 		"LGPL-3.0-or-later": LGPL3OrLater,
 		"MIT":               MIT,
+		"MPL-1.1":           MPL11,
 		"MPL-2.0":           MPL2,
+		"ODC-By-1.0":        ODCBy10,
+		"OFL-1.1":           OFL11,
 		"PSF-2.0":           PSF,
+		"Python-2.0":        Python20,
 		"Unicode-DFS-2015":  Unicode2015,
+		"Unlicense":         Unlicense,
+		"WTFPL":             WTFPL,
 	}
 )
 

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -33,7 +33,8 @@ var (
 		URL: "https://spdx.org/licenses/0BSD.html", AllowedUse: Unrestricted}
 	Apache2 = License{Name: "Apache License 2.0", NoticeFile: true,
 		URL: "https://opensource.org/licenses/Apache-2.0", AllowedUse: Unrestricted}
-	AFL21        = License{Name: "Academic Free License v2.1", URL: "https://spdx.org/licenses/AFL-2.1.html", AllowedUse: Forbidden}
+	AFL21 = License{Name: "Academic Free License v2.1", URL: "https://spdx.org/licenses/AFL-2.1.html",
+		AllowedUse: Unrestricted}
 	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", AllowedUse: Forbidden}
 	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", AllowedUse: Forbidden}
 	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", AllowedUse: Forbidden}
@@ -49,11 +50,12 @@ var (
 	CcBy40 = License{Name: "Creative Commons Attribution 4.0 International",
 		URL: "https://spdx.org/licenses/CC-BY-4.0.html", AllowedUse: OnAmbassadorServers}
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
-		StrongCopyleft: true, URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html", AllowedUse: OnAmbassadorServers}
+		StrongCopyleft: true, URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html",
+		AllowedUse: OnAmbassadorServers}
 	Cc010 = License{Name: "Creative Commons Zero v1.0 Universal",
-		URL: "https://spdx.org/licenses/CC0-1.0.html", AllowedUse: Forbidden}
+		URL: "https://spdx.org/licenses/CC0-1.0.html", AllowedUse: Unrestricted}
 	EPL10 = License{Name: "Eclipse Public License 1.0", URL: "https://spdx.org/licenses/EPL-1.0.html",
-		AllowedUse: Forbidden}
+		AllowedUse: Unrestricted}
 	GPL1Only = License{Name: "GNU General Public License v1.0 only",
 		URL: "https://spdx.org/licenses/GPL-1.0-only.html", AllowedUse: OnAmbassadorServers}
 	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later",
@@ -84,10 +86,10 @@ var (
 		WeakCopyleft: true, URL: "https://spdx.org/licenses/MPL-1.1.html", AllowedUse: Unrestricted}
 	MPL2 = License{Name: "Mozilla Public License 2.0", NoticeFile: true,
 		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", AllowedUse: Unrestricted}
-	ODCBy10 = License{Name: "Open Data Commons Attribution License v1.0", URL: "https://spdx.org/licenses/ODC-By-1.0.html",
-		AllowedUse: Forbidden}
+	ODCBy10 = License{Name: "Open Data Commons Attribution License v1.0",
+		URL: "https://spdx.org/licenses/ODC-By-1.0.html", AllowedUse: Unrestricted}
 	OFL11 = License{Name: "SIL Open Font License 1.1", URL: "https://spdx.org/licenses/OFL-1.1.html",
-		AllowedUse: Forbidden}
+		AllowedUse: Unrestricted}
 	Python20 = License{Name: "Python License 2.0", URL: "https://spdx.org/licenses/Python-2.0.html",
 		AllowedUse: Unrestricted}
 	PSF = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html",
@@ -96,9 +98,9 @@ var (
 	Unicode2015  = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
 		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", AllowedUse: Unrestricted}
 	Unlicense = License{Name: "The Unlicense",
-		URL: "https://spdx.org/licenses/Unlicense.html", AllowedUse: Forbidden}
+		URL: "https://spdx.org/licenses/Unlicense.html", AllowedUse: Unrestricted}
 	WTFPL = License{Name: "Do What The F*ck You Want To Public License",
-		URL: "https://spdx.org/licenses/WTFPL.html", AllowedUse: Forbidden}
+		URL: "https://spdx.org/licenses/WTFPL.html", AllowedUse: Unrestricted}
 )
 
 // https://spdx.org/licenses/

--- a/pkg/detectlicense/validationexceptions.go
+++ b/pkg/detectlicense/validationexceptions.go
@@ -1,0 +1,24 @@
+package detectlicense
+
+import (
+	"fmt"
+	"strings"
+)
+
+func isAmbassadorProprietarySoftware(packageName string) bool {
+	return strings.HasPrefix(packageName, "github.com/datawire/telepresence2-proprietary/")
+}
+
+// knownDependencies will return a list of licenses for any dependency that has been
+// hardcoded due to the difficulty to parse the license file(s).
+func knownDependencies(dependencyName string, dependencyVersion string) (licenses []License, ok bool) {
+	hardcodedDependencies := map[string][]License{
+		"github.com/josharian/intern@v1.0.1-0.20211109044230-42b52b674af5":       {MIT},
+		"github.com/dustin/go-humanize@v1.0.0":                                   {MIT},
+		"github.com/garyburd/redigo/internal@v0.0.0-20150301180006-535138d7bcd7": {Apache2},
+		"github.com/garyburd/redigo/redis@v0.0.0-20150301180006-535138d7bcd7":    {Apache2},
+	}
+
+	licenses, ok = hardcodedDependencies[fmt.Sprintf("%s@%s", dependencyName, dependencyVersion)]
+	return
+}


### PR DESCRIPTION
While scanning Ambassador Cloud, several libraries used licenses that were not recognized by the application.
Changes:
1. Added support in `go-mkopensource` to hard-code some dependencies that are difficult to recognize
2. Added additional JS hard-coded libraries that are difficult to identify
3. Added additional license types the the `detectlicense` and `dependencies` packages