### PR TITLE
Mark github.com/datawire/saas_app and github.com/datawire/telepresence-pro as proprietary

### DIFF
--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -75,7 +75,13 @@ func expectsNotice(licenses map[License]struct{}) bool {
 }
 
 func DetectLicenses(packageName string, files map[string][]byte) (map[License]struct{}, error) {
-	if strings.HasPrefix(packageName, "github.com/datawire/telepresence2-proprietary/") {
+	const SmartAgentRepo = "github.com/datawire/telepresence2-proprietary/"
+	const AmbassadorCloudRepo = "github.com/datawire/saas_app/"
+	const TelepresencePro = "github.com/datawire/telepresence-pro/"
+
+	if strings.HasPrefix(packageName, SmartAgentRepo) ||
+		strings.HasPrefix(packageName, AmbassadorCloudRepo) ||
+		strings.HasPrefix(packageName, TelepresencePro) {
 		// Ambassador's proprietary software has a proprietary license
 		softwareLicenses := map[License]struct{}{AmbassadorProprietary: {}}
 		return softwareLicenses, nil


### PR DESCRIPTION
go-mkopensource has issues detecting licenses for `github.com/datawire/saas_app` and `github.com/datawire/telepresence-pro` because there are no LICENSE* files

These apps are proprietary so they have been marked as such, which will prevent issues when packages in these apps are used in other projects.