### PR TITLE
Add validation for forbidden licenses to js-mkopensource scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ application behaviour.
 * `APPLICATION`: Required. Name of the application being scanned.
   It's used in the header of the license files.
 
+* `APPLICATION_TYPE`: Required. Where will the application being 
+  scanned run.    
+  `internal` is used for anything running on Ambassador Labs servers, 
+  and `external` for anything that's deployed to customer machines. 
+
 * `BUILD_HOME` Required. Location of the root folder of the repo to 
   scan.
 

--- a/build-aux/docker/go_builder.dockerfile
+++ b/build-aux/docker/go_builder.dockerfile
@@ -4,6 +4,9 @@
 ARG GO_BUILDER="base-image-unknown"
 FROM ${GO_BUILDER} as go_dependency_scanner
 
+ARG APPLICATION_TYPE
+ENV APPLICATION_TYPE="${APPLICATION_TYPE}"
+
 RUN apk --no-cache add \
     bash \
     curl \

--- a/build-aux/docker/js_builder.dockerfile
+++ b/build-aux/docker/js_builder.dockerfile
@@ -4,6 +4,9 @@
 ARG NODE_VERSION="10"
 FROM node:${NODE_VERSION}-alpine as npm_dependency_scanner
 
+ARG APPLICATION_TYPE
+ENV APPLICATION_TYPE="${APPLICATION_TYPE}"
+
 RUN apk --no-cache add \
     bash \
     gawk \
@@ -18,4 +21,3 @@ RUN chmod +x *.sh js-mkopensource
 WORKDIR /app
 COPY npm_dependencies.tar ./
 RUN tar xf npm_dependencies.tar && rm -f npm_dependencies.tar
-

--- a/build-aux/docker/scan-js.sh
+++ b/build-aux/docker/scan-js.sh
@@ -22,7 +22,7 @@ scan_npm_package() {
   license-checker --excludePackages "${PKG_NAME}" --customPath "/scripts/customLicenseFormat.json" \
     --json >"${PACKAGE_DEPS}"
 
-  /scripts/js-mkopensource --output-type=json < <(cat "${PACKAGE_DEPS}") >"$2"
+  /scripts/js-mkopensource --application-type=${APPLICATION_TYPE} < <(cat "${PACKAGE_DEPS}") >"$2"
 
   popd >/dev/null
 }

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -10,6 +10,7 @@ BUILD_SCRIPTS=$(dirname $(realpath "$0"))
 . "${BUILD_SCRIPTS}/docker/imports.sh"
 
 validate_required_variable APPLICATION
+validate_required_variable APPLICATION_TYPE
 validate_required_variable BUILD_HOME
 validate_required_variable BUILD_TMP
 
@@ -27,6 +28,7 @@ popd >/dev/null
 
 pushd "${BUILD_HOME}" >/dev/null
 DOCKER_BUILDKIT=1 docker build -f "${BUILD_HOME}/${SCRIPTS_HOME}/build-aux/docker/go_builder.dockerfile" \
+  --build-arg APPLICATION_TYPE="${APPLICATION_TYPE}" \
   --build-arg GIT_TOKEN="${GIT_TOKEN}" \
   --build-arg GO_BUILDER="${GO_BUILDER}" \
   --build-arg SCRIPTS_HOME="${SCRIPTS_HOME}" \
@@ -71,7 +73,10 @@ if [ -n "${NPM_PACKAGES}" ]; then
   popd >/dev/null
 
   pushd "${BUILD_SCRIPTS}/docker" >/dev/null
-  docker build -f js_builder.dockerfile --build-arg NODE_VERSION="${NODE_VERSION}" -t "js-deps-builder" \
+  docker build -f js_builder.dockerfile \
+    --build-arg NODE_VERSION="${NODE_VERSION}" \
+    --build-arg APPLICATION_TYPE="${APPLICATION_TYPE}" \
+    -t "js-deps-builder" \
     --target npm_dependency_scanner .
   popd >/dev/null
 

--- a/cmd/go-mkopensource/dependency.go
+++ b/cmd/go-mkopensource/dependency.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GenerateDependencyList(modNames []string, modLicenses map[string]map[detectlicense.License]struct{},
-	modInfos map[string]*golist.Module, goVersion string, licenseUsage detectlicense.AllowedLicenseUse) (dependencies.DependencyInfo, error) {
+	modInfos map[string]*golist.Module, goVersion string, licenseRestriction detectlicense.LicenseRestriction) (dependencies.DependencyInfo, error) {
 	dependencyList := dependencies.NewDependencyInfo()
 
 	for _, modKey := range modNames {
@@ -34,7 +34,7 @@ func GenerateDependencyList(modNames []string, modLicenses map[string]map[detect
 		dependencyList.Dependencies = append(dependencyList.Dependencies, dependencyDetails)
 	}
 
-	if err := dependencyList.CheckLicenses(licenseUsage); err != nil {
+	if err := dependencyList.CheckLicenses(licenseRestriction); err != nil {
 		return dependencyList, fmt.Errorf("License validation failed: %v\n", err)
 	}
 

--- a/cmd/go-mkopensource/dependency_test.go
+++ b/cmd/go-mkopensource/dependency_test.go
@@ -25,7 +25,7 @@ func TestGenerateDependencyListWhenLicenseIsAllowed(t *testing.T) {
 	_, err := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
 	require.NoError(t, err)
 
-	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, OnAmbassadorServers)
+	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, AmbassadorServers)
 	require.NoError(t, err)
 }
 
@@ -35,6 +35,6 @@ func TestGenerateDependencyListWhenLicenseIsForbidden(t *testing.T) {
 	_, err := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
 	require.Error(t, err)
 
-	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, OnAmbassadorServers)
+	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, AmbassadorServers)
 	require.Error(t, err)
 }

--- a/cmd/go-mkopensource/main_test.go
+++ b/cmd/go-mkopensource/main_test.go
@@ -20,50 +20,36 @@ func TestSuccessfulMarkdownOutput(t *testing.T) {
 	testCases := []struct {
 		testName        string
 		testData        string
-		packagesFlag    string
-		outputTypeFlag  string
 		applicationType string
 	}{
 		{
 			testName:        "01-intern-new - markdown output",
 			testData:        "testdata/01-intern-new",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "markdown",
 			applicationType: "external",
 		},
 		{
 			testName:        "02-replace - markdown output",
 			testData:        "testdata/02-replace",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "markdown",
 			applicationType: "external",
 		},
 		{
 			testName:        "04-nodeps - markdown output",
 			testData:        "testdata/04-nodeps",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "markdown",
 			applicationType: "external",
 		},
 		{
 			testName:        "05-subpatent - markdown output",
 			testData:        "testdata/05-subpatent",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "markdown",
 			applicationType: "external",
 		},
 		{
 			testName:        "One dependency with multiple licenses",
 			testData:        "testdata/06-multiple-licenses",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "markdown",
 			applicationType: "external",
 		},
 		{
 			testName:        "GPL license is allowed for internal use",
 			testData:        "testdata/08-allowed-for-internal-use-only",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "json",
 			applicationType: "internal",
 		},
 	}
@@ -86,8 +72,8 @@ func TestSuccessfulMarkdownOutput(t *testing.T) {
 			actErr := main.Main(&main.CLIArgs{
 				OutputFormat:    "txt",
 				GoTarFilename:   filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
-				Package:         testCase.packagesFlag,
-				OutputType:      testCase.outputTypeFlag,
+				Package:         "mod",
+				OutputType:      "markdown",
 				ApplicationType: testCase.applicationType,
 			})
 
@@ -109,50 +95,36 @@ func TestSuccessfulJsonOutput(t *testing.T) {
 	testCases := []struct {
 		testName        string
 		testData        string
-		packagesFlag    string
-		outputTypeFlag  string
 		applicationType string
 	}{
 		{
 			testName:        "01-intern-new",
 			testData:        "testdata/01-intern-new",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "json",
 			applicationType: "external",
 		},
 		{
 			testName:        "02-replace",
 			testData:        "testdata/02-replace",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "json",
 			applicationType: "external",
 		},
 		{
 			testName:        "04-nodeps",
 			testData:        "testdata/04-nodeps",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "json",
 			applicationType: "external",
 		},
 		{
 			testName:        "05-subpatent",
 			testData:        "testdata/05-subpatent",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "json",
 			applicationType: "external",
 		},
 		{
 			testName:        "One dependency with multiple licenses",
 			testData:        "testdata/06-multiple-licenses",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "json",
 			applicationType: "external",
 		},
 		{
 			testName:        "GPL license is allowed for internal use",
 			testData:        "testdata/08-allowed-for-internal-use-only",
-			packagesFlag:    "mod",
-			outputTypeFlag:  "json",
 			applicationType: "internal",
 		},
 	}
@@ -175,8 +147,8 @@ func TestSuccessfulJsonOutput(t *testing.T) {
 			actErr := main.Main(&main.CLIArgs{
 				OutputFormat:    "txt",
 				GoTarFilename:   filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
-				Package:         testCase.packagesFlag,
-				OutputType:      testCase.outputTypeFlag,
+				Package:         "mod",
+				OutputType:      "json",
 				ApplicationType: testCase.applicationType,
 			})
 

--- a/cmd/go-mkopensource/main_test.go
+++ b/cmd/go-mkopensource/main_test.go
@@ -18,46 +18,53 @@ import (
 
 func TestSuccessfulMarkdownOutput(t *testing.T) {
 	testCases := []struct {
-		testName       string
-		testData       string
-		packagesFlag   string
-		outputTypeFlag string
-		expectedOutput string
+		testName        string
+		testData        string
+		packagesFlag    string
+		outputTypeFlag  string
+		applicationType string
 	}{
 		{
-			testName:       "01-intern-new - markdown output",
-			testData:       "testdata/01-intern-new",
-			packagesFlag:   "mod",
-			outputTypeFlag: "markdown",
-			expectedOutput: "expected_markdown_output.txt",
+			testName:        "01-intern-new - markdown output",
+			testData:        "testdata/01-intern-new",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "markdown",
+			applicationType: "external",
 		},
 		{
-			testName:       "02-replace - markdown output",
-			testData:       "testdata/02-replace",
-			packagesFlag:   "mod",
-			outputTypeFlag: "markdown",
-			expectedOutput: "expected_markdown_output.txt",
+			testName:        "02-replace - markdown output",
+			testData:        "testdata/02-replace",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "markdown",
+			applicationType: "external",
 		},
 		{
-			testName:       "04-nodeps - markdown output",
-			testData:       "testdata/04-nodeps",
-			packagesFlag:   "mod",
-			outputTypeFlag: "markdown",
-			expectedOutput: "expected_markdown_output.txt",
+			testName:        "04-nodeps - markdown output",
+			testData:        "testdata/04-nodeps",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "markdown",
+			applicationType: "external",
 		},
 		{
-			testName:       "05-subpatent - markdown output",
-			testData:       "testdata/05-subpatent",
-			packagesFlag:   "mod",
-			outputTypeFlag: "markdown",
-			expectedOutput: "expected_markdown_output.txt",
+			testName:        "05-subpatent - markdown output",
+			testData:        "testdata/05-subpatent",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "markdown",
+			applicationType: "external",
 		},
 		{
-			testName:       "06-multiple-licenses - markdown output",
-			testData:       "testdata/06-multiple-licenses",
-			packagesFlag:   "mod",
-			outputTypeFlag: "markdown",
-			expectedOutput: "expected_markdown_output.txt",
+			testName:        "One dependency with multiple licenses",
+			testData:        "testdata/06-multiple-licenses",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "markdown",
+			applicationType: "external",
+		},
+		{
+			testName:        "GPL license is allowed for internal use",
+			testData:        "testdata/08-allowed-for-internal-use-only",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "json",
+			applicationType: "internal",
 		},
 	}
 
@@ -77,10 +84,11 @@ func TestSuccessfulMarkdownOutput(t *testing.T) {
 			}()
 
 			actErr := main.Main(&main.CLIArgs{
-				OutputFormat:  "txt",
-				GoTarFilename: filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
-				Package:       testCase.packagesFlag,
-				OutputType:    testCase.outputTypeFlag,
+				OutputFormat:    "txt",
+				GoTarFilename:   filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
+				Package:         testCase.packagesFlag,
+				OutputType:      testCase.outputTypeFlag,
+				ApplicationType: testCase.applicationType,
 			})
 
 			_ = w.Close()
@@ -90,7 +98,7 @@ func TestSuccessfulMarkdownOutput(t *testing.T) {
 			programOutput, readErr := io.ReadAll(r)
 			require.NoError(t, readErr)
 
-			expectedOutput := getFileContents(t, testCase.expectedOutput)
+			expectedOutput := getFileContents(t, "expected_markdown_output.txt")
 
 			assert.Equal(t, string(expectedOutput), string(programOutput))
 		})
@@ -99,46 +107,53 @@ func TestSuccessfulMarkdownOutput(t *testing.T) {
 
 func TestSuccessfulJsonOutput(t *testing.T) {
 	testCases := []struct {
-		testName       string
-		testData       string
-		packagesFlag   string
-		outputTypeFlag string
-		expectedOutput string
+		testName        string
+		testData        string
+		packagesFlag    string
+		outputTypeFlag  string
+		applicationType string
 	}{
 		{
-			testName:       "01-intern-new - json output",
-			testData:       "testdata/01-intern-new",
-			packagesFlag:   "mod",
-			outputTypeFlag: "json",
-			expectedOutput: "expected_json_output.json",
+			testName:        "01-intern-new",
+			testData:        "testdata/01-intern-new",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "json",
+			applicationType: "external",
 		},
 		{
-			testName:       "02-replace - json output",
-			testData:       "testdata/02-replace",
-			packagesFlag:   "mod",
-			outputTypeFlag: "json",
-			expectedOutput: "expected_json_output.json",
+			testName:        "02-replace",
+			testData:        "testdata/02-replace",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "json",
+			applicationType: "external",
 		},
 		{
-			testName:       "04-nodeps - json output",
-			testData:       "testdata/04-nodeps",
-			packagesFlag:   "mod",
-			outputTypeFlag: "json",
-			expectedOutput: "expected_json_output.json",
+			testName:        "04-nodeps",
+			testData:        "testdata/04-nodeps",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "json",
+			applicationType: "external",
 		},
 		{
-			testName:       "05-subpatent - json output",
-			testData:       "testdata/05-subpatent",
-			packagesFlag:   "mod",
-			outputTypeFlag: "json",
-			expectedOutput: "expected_json_output.json",
+			testName:        "05-subpatent",
+			testData:        "testdata/05-subpatent",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "json",
+			applicationType: "external",
 		},
 		{
-			testName:       "06-multiple-licenses - json output",
-			testData:       "testdata/06-multiple-licenses",
-			packagesFlag:   "mod",
-			outputTypeFlag: "json",
-			expectedOutput: "expected_json_output.json",
+			testName:        "One dependency with multiple licenses",
+			testData:        "testdata/06-multiple-licenses",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "json",
+			applicationType: "external",
+		},
+		{
+			testName:        "GPL license is allowed for internal use",
+			testData:        "testdata/08-allowed-for-internal-use-only",
+			packagesFlag:    "mod",
+			outputTypeFlag:  "json",
+			applicationType: "internal",
 		},
 	}
 
@@ -158,10 +173,11 @@ func TestSuccessfulJsonOutput(t *testing.T) {
 			}()
 
 			actErr := main.Main(&main.CLIArgs{
-				OutputFormat:  "txt",
-				GoTarFilename: filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
-				Package:       testCase.packagesFlag,
-				OutputType:    testCase.outputTypeFlag,
+				OutputFormat:    "txt",
+				GoTarFilename:   filepath.Join("..", "go1.17.3-testdata.src.tar.gz"),
+				Package:         testCase.packagesFlag,
+				OutputType:      testCase.outputTypeFlag,
+				ApplicationType: testCase.applicationType,
 			})
 
 			_ = w.Close()
@@ -169,7 +185,7 @@ func TestSuccessfulJsonOutput(t *testing.T) {
 			require.NoError(t, actErr)
 
 			jsonOutput := getDependencyInfoFromReader(t, r)
-			expectedJson := getDependencyInfoFromFile(t, testCase.expectedOutput)
+			expectedJson := getDependencyInfoFromFile(t, "expected_json_output.json")
 
 			assert.Equal(t, expectedJson, jsonOutput)
 		})

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_json_output.json
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_json_output.json
@@ -1,0 +1,22 @@
+{
+  "dependencies": [
+    {
+      "name": "the Go language standard library (\"std\")",
+      "version": "v1.17.3",
+      "licenses": [
+        "3-clause BSD license"
+      ]
+    },
+    {
+      "name": "example.com/gpl",
+      "version": "(modified)",
+      "licenses": [
+        "GNU General Public License v1.0 or later"
+      ]
+    }
+  ],
+  "licenseInfo": {
+    "3-clause BSD license": "https://opensource.org/licenses/BSD-3-Clause",
+    "GNU General Public License v1.0 or later": "https://spdx.org/licenses/GPL-1.0-or-later.html"
+  }
+}

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_markdown_output.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_markdown_output.txt
@@ -1,7 +1,7 @@
 The Go module "testmod" incorporates the following Free and Open Source
 software:
 
-    Name                                      Version      License(s)
-    ----                                      -------      ----------
-    the Go language standard library ("std")  v1.17.3      3-clause BSD license
-    example.com/gpl                           (modified)   GNU General Public License v1.0 or later
+    Name                                      Version     License(s)
+    ----                                      -------     ----------
+    the Go language standard library ("std")  v1.17.3     3-clause BSD license
+    example.com/gpl                           (modified)  GNU General Public License v1.0 or later

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_markdown_output.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_markdown_output.txt
@@ -1,0 +1,7 @@
+The Go module "testmod" incorporates the following Free and Open Source
+software:
+
+    Name                                      Version      License(s)
+    ----                                      -------      ----------
+    the Go language standard library ("std")  v1.17.3      3-clause BSD license
+    example.com/gpl                           (modified)   GNU General Public License v1.0 or later

--- a/cmd/js-mkopensource/dependency/dependency_test.go
+++ b/cmd/js-mkopensource/dependency/dependency_test.go
@@ -3,6 +3,7 @@ package dependency_test
 import (
 	"github.com/datawire/go-mkopensource/cmd/js-mkopensource/dependency"
 	"github.com/datawire/go-mkopensource/pkg/dependencies"
+	"github.com/datawire/go-mkopensource/pkg/detectlicense"
 	"github.com/stretchr/testify/require"
 	"io"
 	"os"
@@ -31,6 +32,10 @@ func TestSuccessfulGeneration(t *testing.T) {
 			"Hardcoded dependencies are properly parsed",
 			"./testdata/hardcoded-dependencies",
 		},
+		{
+			"GPL license is allowed in internal software",
+			"./testdata/dependency-with-gpl-license",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -40,7 +45,7 @@ func TestSuccessfulGeneration(t *testing.T) {
 			defer func() { _ = nodeDependencies.Close() }()
 
 			// Act
-			dependencyInformation, err := dependency.GetDependencyInformation(nodeDependencies)
+			dependencyInformation, err := dependency.GetDependencyInformation(nodeDependencies, detectlicense.AmbassadorServers)
 			require.NoError(t, err)
 
 			// Assert
@@ -71,6 +76,10 @@ func TestErrorScenarios(t *testing.T) {
 			"Hardcode dependency with different version is rejected",
 			"./testdata/hardcoded-dependencies-but-different-version",
 		},
+		{
+			"GPL license is not allowed in distributed software",
+			"./testdata/dependency-with-gpl-license",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -80,7 +89,7 @@ func TestErrorScenarios(t *testing.T) {
 			defer func() { _ = nodeDependencies.Close() }()
 
 			// Act
-			_, err := dependency.GetDependencyInformation(nodeDependencies)
+			_, err := dependency.GetDependencyInformation(nodeDependencies, detectlicense.Unrestricted)
 
 			// Assert
 			require.Error(t, err)

--- a/cmd/js-mkopensource/dependency/testdata/dependency-with-gpl-license/dependencies.json
+++ b/cmd/js-mkopensource/dependency/testdata/dependency-with-gpl-license/dependencies.json
@@ -1,0 +1,12 @@
+{
+  "atob@2.1.2": {
+    "licenses": "GPL-1.0-only",
+    "repository": "https://github.com/mapbox/node-pre-gyp",
+    "publisher": "Dane Springmeyer",
+    "email": "dane@mapbox.com",
+    "dependencyPath": "/app/node_modules/@mapbox/node-pre-gyp",
+    "path": "/app/node_modules/@mapbox/node-pre-gyp",
+    "licenseFile": "/app/node_modules/@mapbox/node-pre-gyp/LICENSE"
+  }
+}
+

--- a/cmd/js-mkopensource/dependency/testdata/dependency-with-gpl-license/expected_output.json
+++ b/cmd/js-mkopensource/dependency/testdata/dependency-with-gpl-license/expected_output.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": [
+    {
+      "name": "atob",
+      "version": "2.1.2",
+      "licenses": [
+        "GNU General Public License v1.0 only"
+      ]
+    }
+  ],
+  "licenseInfo": {
+    "GNU General Public License v1.0 only": "https://spdx.org/licenses/GPL-1.0-only.html"
+  }
+}

--- a/cmd/js-mkopensource/exitcodes.go
+++ b/cmd/js-mkopensource/exitcodes.go
@@ -3,7 +3,9 @@ package main
 type exitCode int
 
 const (
+	NoError                   exitCode = 0
 	DependencyGenerationError exitCode = 1
 	MarshallJsonError         exitCode = 2
 	WriteError                exitCode = 3
+	InvalidArgumentsError     exitCode = 4
 )

--- a/cmd/js-mkopensource/main.go
+++ b/cmd/js-mkopensource/main.go
@@ -4,11 +4,37 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/datawire/go-mkopensource/cmd/js-mkopensource/dependency"
+	"github.com/datawire/go-mkopensource/pkg/detectlicense"
+	"github.com/spf13/pflag"
 	"os"
 )
 
+const (
+	// Validations to do on the licenses.
+	// The only validation for "internal" is to check chat forbidden licenses are not used
+	internalApplication = "internal"
+	// "external" applications have additional license requirements as documented in
+	//https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157
+	externalApplication = "external"
+)
+
+type CLIArgs struct {
+	ApplicationType string
+}
+
 func main() {
-	dependencyInfo, err := dependency.GetDependencyInformation(os.Stdin)
+	args, err := parseArgs()
+	if err != nil {
+		if err == pflag.ErrHelp {
+			os.Exit(int(NoError))
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "%s: %v\nTry '%s --help' for more information.\n", os.Args[0], err, os.Args[0])
+		os.Exit(int(InvalidArgumentsError))
+	}
+
+	licenseRestriction := getLicenseRestriction(args.ApplicationType)
+
+	dependencyInfo, err := dependency.GetDependencyInformation(os.Stdin, licenseRestriction)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error generating dependency information: %v\n", err)
 		os.Exit(int(DependencyGenerationError))
@@ -26,4 +52,47 @@ func main() {
 	}
 
 	_, _ = fmt.Fprintf(os.Stdout, "\n")
+}
+
+func parseArgs() (*CLIArgs, error) {
+	args := &CLIArgs{}
+	argparser := pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
+	help := false
+	argparser.BoolVarP(&help, "help", "h", false, "Show this message")
+	argparser.StringVar(&args.ApplicationType, "application-type", externalApplication,
+		fmt.Sprintf("Where will the application run. One of: %s, %s\n"+
+			"Internal applications are run on Ambassador servers.\n"+
+			"External applications run on client-controlled infrastructure", internalApplication, externalApplication))
+
+	if err := argparser.Parse(os.Args[1:]); err != nil {
+		return nil, err
+	}
+	if help {
+		fmt.Printf("Usage: %v OPTIONS\n", os.Args[0])
+		fmt.Println()
+		fmt.Println("OPTIONS:")
+		argparser.PrintDefaults()
+		return nil, pflag.ErrHelp
+	}
+
+	if argparser.NArg() != 0 {
+		return nil, fmt.Errorf("expected 0 arguments, got %d: %q", argparser.NArg(), argparser.Args())
+	}
+
+	if args.ApplicationType != internalApplication && args.ApplicationType != externalApplication {
+		return nil, fmt.Errorf("--application-type must be one of '%s', '%s'", internalApplication, externalApplication)
+	}
+
+	return args, nil
+}
+
+func getLicenseRestriction(applicationType string) detectlicense.LicenseRestriction {
+	var LicenseRestriction detectlicense.LicenseRestriction
+	switch applicationType {
+	case internalApplication:
+		LicenseRestriction = detectlicense.AmbassadorServers
+	default:
+		LicenseRestriction = detectlicense.Unrestricted
+	}
+	return LicenseRestriction
 }

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -107,8 +107,8 @@ func getLicenseFromName(licenseName string) (License, error) {
 // CheckLicenses checks that the licenses used by the dependencies are known and allowed to be used
 //in an application based on the buiness logic described here: https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157.
 //This function must be called after parsing of the licenses has been done.
-func (d *DependencyInfo) CheckLicenses(allowedLicenses AllowedLicenseUse) error {
-	if allowedLicenses == Forbidden {
+func (d *DependencyInfo) CheckLicenses(licenseRestriction LicenseRestriction) error {
+	if licenseRestriction == Forbidden {
 		return fmt.Errorf("forbidden licenses should not be used")
 	}
 
@@ -119,11 +119,11 @@ func (d *DependencyInfo) CheckLicenses(allowedLicenses AllowedLicenseUse) error 
 				return err
 			}
 
-			if license.AllowedUse == Forbidden {
+			if license.Restriction == Forbidden {
 				return fmt.Errorf("license '%s' is forbidden", license.Name)
 			}
 
-			if license.AllowedUse < allowedLicenses {
+			if license.Restriction < licenseRestriction {
 				return fmt.Errorf("license '%s' should not be used since it should not run on customer servers", license.Name)
 			}
 		}

--- a/pkg/dependencies/dependencyinfo_test.go
+++ b/pkg/dependencies/dependencyinfo_test.go
@@ -198,7 +198,7 @@ func TestCheckLicensesValidatesAllowedLicenseCorrectly(t *testing.T) {
 	testCases := []struct {
 		Name            string
 		dependencies    dependencies.DependencyInfo
-		allowedLicenses detectlicense.AllowedLicenseUse
+		allowedLicenses detectlicense.LicenseRestriction
 	}{
 		{
 			"Empty dependency list is always allowed",
@@ -208,7 +208,7 @@ func TestCheckLicensesValidatesAllowedLicenseCorrectly(t *testing.T) {
 		{
 			"Unrestricted licenses are OK on Ambassador Labs servers",
 			unrestrictedLicensesOnly,
-			detectlicense.OnAmbassadorServers,
+			detectlicense.AmbassadorServers,
 		},
 		{
 			"Unrestricted licenses are OK everywhere",
@@ -218,12 +218,12 @@ func TestCheckLicensesValidatesAllowedLicenseCorrectly(t *testing.T) {
 		{
 			"Restricted licenses are OK on Ambassador Labs servers",
 			licensesForAmbassadorServersOnly,
-			detectlicense.OnAmbassadorServers,
+			detectlicense.AmbassadorServers,
 		},
 		{
 			"Mix of licenses without forbidden is allowed on Ambassador Labs servers",
 			mixOfLicensesWithoutForbidden,
-			detectlicense.OnAmbassadorServers,
+			detectlicense.AmbassadorServers,
 		},
 	}
 
@@ -239,7 +239,7 @@ func TestCheckLicensesValidatesForbiddenLicensesCorrectly(t *testing.T) {
 	testCases := []struct {
 		Name            string
 		dependencies    dependencies.DependencyInfo
-		allowedLicenses detectlicense.AllowedLicenseUse
+		allowedLicenses detectlicense.LicenseRestriction
 	}{
 		{
 			"It's not possible to allow the use of forbidden licenses by mistake",
@@ -249,7 +249,7 @@ func TestCheckLicensesValidatesForbiddenLicensesCorrectly(t *testing.T) {
 		{
 			"Forbidden licenses are not allowed on Ambassador Labs servers",
 			forbiddenLicensesOnly,
-			detectlicense.OnAmbassadorServers,
+			detectlicense.AmbassadorServers,
 		},
 		{
 			"Forbidden licenses are not allowed on customer servers",

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -33,7 +33,8 @@ var (
 		URL: "https://spdx.org/licenses/0BSD.html", Restriction: Unrestricted}
 	Apache2 = License{Name: "Apache License 2.0", NoticeFile: true,
 		URL: "https://opensource.org/licenses/Apache-2.0", Restriction: Unrestricted}
-	AFL21        = License{Name: "Academic Free License v2.1", URL: "https://spdx.org/licenses/AFL-2.1.html", Restriction: Forbidden}
+	AFL21 = License{Name: "Academic Free License v2.1", URL: "https://spdx.org/licenses/AFL-2.1.html",
+		Restriction: Unrestricted}
 	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", Restriction: Forbidden}
 	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", Restriction: Forbidden}
 	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", Restriction: Forbidden}
@@ -51,9 +52,9 @@ var (
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
 		StrongCopyleft: true, URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html", Restriction: AmbassadorServers}
 	Cc010 = License{Name: "Creative Commons Zero v1.0 Universal",
-		URL: "https://spdx.org/licenses/CC0-1.0.html", Restriction: Forbidden}
+		URL: "https://spdx.org/licenses/CC0-1.0.html", Restriction: Unrestricted}
 	EPL10 = License{Name: "Eclipse Public License 1.0", URL: "https://spdx.org/licenses/EPL-1.0.html",
-		Restriction: Forbidden}
+		Restriction: Unrestricted}
 	GPL1Only = License{Name: "GNU General Public License v1.0 only",
 		URL: "https://spdx.org/licenses/GPL-1.0-only.html", Restriction: AmbassadorServers}
 	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later",
@@ -85,9 +86,9 @@ var (
 	MPL2 = License{Name: "Mozilla Public License 2.0", NoticeFile: true,
 		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", Restriction: Unrestricted}
 	ODCBy10 = License{Name: "Open Data Commons Attribution License v1.0", URL: "https://spdx.org/licenses/ODC-By-1.0.html",
-		Restriction: Forbidden}
+		Restriction: Unrestricted}
 	OFL11 = License{Name: "SIL Open Font License 1.1", URL: "https://spdx.org/licenses/OFL-1.1.html",
-		Restriction: Forbidden}
+		Restriction: Unrestricted}
 	Python20 = License{Name: "Python License 2.0", URL: "https://spdx.org/licenses/Python-2.0.html",
 		Restriction: Unrestricted}
 	PSF = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html",
@@ -96,9 +97,9 @@ var (
 	Unicode2015  = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
 		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", Restriction: Unrestricted}
 	Unlicense = License{Name: "The Unlicense",
-		URL: "https://spdx.org/licenses/Unlicense.html", Restriction: Forbidden}
+		URL: "https://spdx.org/licenses/Unlicense.html", Restriction: Unrestricted}
 	WTFPL = License{Name: "Do What The F*ck You Want To Public License",
-		URL: "https://spdx.org/licenses/WTFPL.html", Restriction: Forbidden}
+		URL: "https://spdx.org/licenses/WTFPL.html", Restriction: Unrestricted}
 )
 
 // https://spdx.org/licenses/

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -9,98 +9,96 @@ import (
 	"strings"
 )
 
-type AllowedLicenseUse int
+type LicenseRestriction int
 
 const (
-	Forbidden AllowedLicenseUse = iota
-	OnAmbassadorServers
+	Forbidden LicenseRestriction = iota
+	AmbassadorServers
 	Unrestricted
 )
 
 type License struct {
 	Name           string
-	NoticeFile     bool              // are NOTICE files "a thing" for this license?
-	WeakCopyleft   bool              // requires that library to be open-source
-	StrongCopyleft bool              // requires the resulting program to be open-source
-	URL            string            // Location of the license description
-	AllowedUse     AllowedLicenseUse // Where is this license allowed
+	NoticeFile     bool               // are NOTICE files "a thing" for this license?
+	WeakCopyleft   bool               // requires that library to be open-source
+	StrongCopyleft bool               // requires the resulting program to be open-source
+	URL            string             // Location of the license description
+	Restriction    LicenseRestriction // Where is this license allowed
 }
 
 //nolint:gochecknoglobals // Would be 'const'.
 var (
 	AmbassadorProprietary = License{Name: "proprietary Ambassador software"}
 	ZeroBSD               = License{Name: "BSD Zero Clause License",
-		URL: "https://spdx.org/licenses/0BSD.html", AllowedUse: Unrestricted}
+		URL: "https://spdx.org/licenses/0BSD.html", Restriction: Unrestricted}
 	Apache2 = License{Name: "Apache License 2.0", NoticeFile: true,
-		URL: "https://opensource.org/licenses/Apache-2.0", AllowedUse: Unrestricted}
-	AFL21 = License{Name: "Academic Free License v2.1", URL: "https://spdx.org/licenses/AFL-2.1.html",
-		AllowedUse: Unrestricted}
-	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", AllowedUse: Forbidden}
-	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", AllowedUse: Forbidden}
-	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", AllowedUse: Forbidden}
-	AGPL3OrLater = License{Name: "GNU Affero General Public License v3.0 or later", AllowedUse: Forbidden}
+		URL: "https://opensource.org/licenses/Apache-2.0", Restriction: Unrestricted}
+	AFL21        = License{Name: "Academic Free License v2.1", URL: "https://spdx.org/licenses/AFL-2.1.html", Restriction: Forbidden}
+	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", Restriction: Forbidden}
+	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", Restriction: Forbidden}
+	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", Restriction: Forbidden}
+	AGPL3OrLater = License{Name: "GNU Affero General Public License v3.0 or later", Restriction: Forbidden}
 	BSD1         = License{Name: "1-clause BSD license", URL: "https://opensource.org/licenses/BSD-1-Clause",
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	BSD2 = License{Name: "2-clause BSD license", URL: "https://opensource.org/licenses/BSD-2-Clause",
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	BSD3 = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause",
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	CcBy30 = License{Name: "Creative Commons Attribution 3.0 Unported",
-		URL: "https://spdx.org/licenses/CC-BY-3.0.html", AllowedUse: OnAmbassadorServers}
+		URL: "https://spdx.org/licenses/CC-BY-3.0.html", Restriction: AmbassadorServers}
 	CcBy40 = License{Name: "Creative Commons Attribution 4.0 International",
-		URL: "https://spdx.org/licenses/CC-BY-4.0.html", AllowedUse: OnAmbassadorServers}
+		URL: "https://spdx.org/licenses/CC-BY-4.0.html", Restriction: AmbassadorServers}
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
-		StrongCopyleft: true, URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html",
-		AllowedUse: OnAmbassadorServers}
+		StrongCopyleft: true, URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html", Restriction: AmbassadorServers}
 	Cc010 = License{Name: "Creative Commons Zero v1.0 Universal",
-		URL: "https://spdx.org/licenses/CC0-1.0.html", AllowedUse: Unrestricted}
+		URL: "https://spdx.org/licenses/CC0-1.0.html", Restriction: Forbidden}
 	EPL10 = License{Name: "Eclipse Public License 1.0", URL: "https://spdx.org/licenses/EPL-1.0.html",
-		AllowedUse: Unrestricted}
+		Restriction: Forbidden}
 	GPL1Only = License{Name: "GNU General Public License v1.0 only",
-		URL: "https://spdx.org/licenses/GPL-1.0-only.html", AllowedUse: OnAmbassadorServers}
+		URL: "https://spdx.org/licenses/GPL-1.0-only.html", Restriction: AmbassadorServers}
 	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later",
-		URL: "https://spdx.org/licenses/GPL-1.0-or-later.html", AllowedUse: OnAmbassadorServers}
+		URL: "https://spdx.org/licenses/GPL-1.0-or-later.html", Restriction: AmbassadorServers}
 	GPL2Only = License{Name: "GNU General Public License v2.0 only",
-		URL: "https://spdx.org/licenses/GPL-2.0-only.html", AllowedUse: OnAmbassadorServers}
+		URL: "https://spdx.org/licenses/GPL-2.0-only.html", Restriction: AmbassadorServers}
 	GPL2OrLater = License{Name: "GNU General Public License v2.0 or later",
-		URL: "https://spdx.org/licenses/GPL-2.0-or-later.html", AllowedUse: OnAmbassadorServers}
+		URL: "https://spdx.org/licenses/GPL-2.0-or-later.html", Restriction: AmbassadorServers}
 	GPL3Only = License{Name: "GNU General Public License v3.0 only", StrongCopyleft: true,
-		URL: "https://spdx.org/licenses/GPL-3.0.html", AllowedUse: OnAmbassadorServers}
+		URL: "https://spdx.org/licenses/GPL-3.0.html", Restriction: AmbassadorServers}
 	GPL3OrLater = License{Name: "GNU General Public License v3.0 or later",
-		URL: "https://spdx.org/licenses/GPL-3.0-or-later.html", AllowedUse: OnAmbassadorServers}
-	ISC       = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC", AllowedUse: Unrestricted}
+		URL: "https://spdx.org/licenses/GPL-3.0-or-later.html", Restriction: AmbassadorServers}
+	ISC       = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC", Restriction: Unrestricted}
 	LGPL2Only = License{Name: "GNU Library General Public License v2 only", WeakCopyleft: true,
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	LGPL2OrLater = License{Name: "GNU Library General Public License v2 or later", WeakCopyleft: true,
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	LGPL21Only = License{Name: "GNU Lesser General Public License v2.1 only", WeakCopyleft: true,
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	LGPL21OrLater = License{Name: "GNU Lesser General Public License v2.1 or later", WeakCopyleft: true,
-		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html", AllowedUse: Unrestricted}
+		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html", Restriction: Unrestricted}
 	LGPL3Only = License{Name: "GNU Lesser General Public License v3.0 only", WeakCopyleft: true,
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	LGPL3OrLater = License{Name: "GNU Lesser General Public License v3.0 or later", WeakCopyleft: true,
-		AllowedUse: Unrestricted}
-	MIT   = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT", AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
+	MIT   = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT", Restriction: Unrestricted}
 	MPL11 = License{Name: "Mozilla Public License 1.1", NoticeFile: true,
-		WeakCopyleft: true, URL: "https://spdx.org/licenses/MPL-1.1.html", AllowedUse: Unrestricted}
+		WeakCopyleft: true, URL: "https://spdx.org/licenses/MPL-1.1.html", Restriction: Unrestricted}
 	MPL2 = License{Name: "Mozilla Public License 2.0", NoticeFile: true,
-		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", AllowedUse: Unrestricted}
-	ODCBy10 = License{Name: "Open Data Commons Attribution License v1.0",
-		URL: "https://spdx.org/licenses/ODC-By-1.0.html", AllowedUse: Unrestricted}
+		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", Restriction: Unrestricted}
+	ODCBy10 = License{Name: "Open Data Commons Attribution License v1.0", URL: "https://spdx.org/licenses/ODC-By-1.0.html",
+		Restriction: Forbidden}
 	OFL11 = License{Name: "SIL Open Font License 1.1", URL: "https://spdx.org/licenses/OFL-1.1.html",
-		AllowedUse: Unrestricted}
+		Restriction: Forbidden}
 	Python20 = License{Name: "Python License 2.0", URL: "https://spdx.org/licenses/Python-2.0.html",
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	PSF = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html",
-		AllowedUse: Unrestricted}
+		Restriction: Unrestricted}
 	PublicDomain = License{Name: "Public domain"}
 	Unicode2015  = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
-		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", AllowedUse: Unrestricted}
+		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", Restriction: Unrestricted}
 	Unlicense = License{Name: "The Unlicense",
-		URL: "https://spdx.org/licenses/Unlicense.html", AllowedUse: Unrestricted}
+		URL: "https://spdx.org/licenses/Unlicense.html", Restriction: Forbidden}
 	WTFPL = License{Name: "Do What The F*ck You Want To Public License",
-		URL: "https://spdx.org/licenses/WTFPL.html", AllowedUse: Unrestricted}
+		URL: "https://spdx.org/licenses/WTFPL.html", Restriction: Forbidden}
 )
 
 // https://spdx.org/licenses/


### PR DESCRIPTION
This PR adds a check to `js-mkopensource` that will cause a failure if a  forbidden license  (as documented [here](https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157)) is used by any dependency.

Since allowed licenses depend on how the software is used (Ambassador servers _vs_ customer machines), there is a command line option `--application-type` that changes the logic applied for validation.
`go-mkopensource` was refactored to make code more clear and consistent with `js-mkopensource`.

Scripts that generate dependency files were also updated to read value of environment variable `APPLICATION_TYPE` and use it
as at the value for parameter `--application-type` when calling `go-mkopensource` and `js-mkopensource`