### PR TITLE
Fixes required to fix issues in Ambassador Cloud build

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ application behaviour.
 
   `export PYTHON_PACKAGES="./python/requirements.txt ./builder/requirements.txt"`
 
-* `PYTHON_BUILDER`: Required. Image to use for generating Python 
+* `PYTHON_IMAGE`: Required. Image to use for generating Python 
   dependencies.
 
 * `NPM_PACKAGES`: Optional. List of package.json and package-lock.json 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ application behaviour.
 * `GIT_TOKEN` Required. Git token with permissions to pull 
   repositories
 
-* `GO_BUILDER` Required. Image to use for generating Python
+* `GO_IMAGE` Required. Image to use for generating Go
   dependencies.
 
 * `PYTHON_PACKAGES`: Optional. List of requirement.txt files to scan.

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ application behaviour.
 
   `export NPM_PACKAGES="./tools/sandbox/grpc_web/package.json ./tools/sandbox/grpc_web/package-lock.json"`
 
-* `NODE_VERSION`: Required when `NPM_PACKAGES` is defined. Version 
+* `NODE_IMAGE`: Required when `NPM_PACKAGES` is defined. Version 
   of Node.JS to use when running npm dependency scan. Only valid
   version numbers (X.Y.Z) are allowed.  
   Example:
 
-  `NODE_VERSION=10`
+  `NODE_IMAGE=node:14.13.1-alpine`
 
 * `SCRIPTS_HOME`: Required. Location where `go-mkopensource` repo is 
   checked out, relative to  `BUILD_HOME`

--- a/build-aux/docker/js_builder.dockerfile
+++ b/build-aux/docker/js_builder.dockerfile
@@ -1,8 +1,21 @@
 ######################################################################
 # builder for Js scanning
 ######################################################################
-ARG NODE_VERSION="10"
-FROM node:${NODE_VERSION}-alpine as npm_dependency_scanner
+ARG NODE_IMAGE="need-a-base-image"
+FROM golang:1.17-alpine3.15 as builder
+
+WORKDIR /src
+COPY . ./
+
+ARG SCRIPTS_HOME
+WORKDIR /src/${SCRIPTS_HOME}/cmd/js-mkopensource
+
+RUN mkdir /out
+RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o /out/ .
+WORKDIR /src/${SCRIPTS_HOME}/build-aux/docker/
+RUN cp scan-js.sh imports.sh customLicenseFormat.json npm_dependencies.tar /out/
+
+FROM ${NODE_IMAGE} as npm_dependency_scanner
 
 ARG APPLICATION_TYPE
 ENV APPLICATION_TYPE="${APPLICATION_TYPE}"
@@ -15,9 +28,8 @@ RUN apk --no-cache add \
 RUN npm install -g license-checker@25.0.1
 
 WORKDIR /scripts
-COPY js-mkopensource *.sh customLicenseFormat.json ./
+COPY --from=builder /out/* ./
 RUN chmod +x *.sh js-mkopensource
 
 WORKDIR /app
-COPY npm_dependencies.tar ./
-RUN tar xf npm_dependencies.tar && rm -f npm_dependencies.tar
+RUN tar xf /scripts/npm_dependencies.tar

--- a/build-aux/docker/scan-go.sh
+++ b/build-aux/docker/scan-go.sh
@@ -14,5 +14,7 @@ GO_VERSION=$(go version | sed -E 's/.*go([1-9\.]*).*/\1/')
 /scripts/go-mkopensource --output-format=txt --package=mod --output-type=markdown --gotar="$(ls /data/go*.src.tar.gz)" >"${GO_DEPENDENCIES}"
 
 DEPENDENCY_INFO="${BUILD_TMP}/go_dependencies.json"
-/scripts/go-mkopensource --output-format=txt --package=mod --output-type=json --gotar="$(ls /data/go*.src.tar.gz)" >"${DEPENDENCY_INFO}"
+/scripts/go-mkopensource --output-format=txt --package=mod --output-type=json --application-type=${APPLICATION_TYPE} \
+  --gotar="$(ls /data/go*.src.tar.gz)" >"${DEPENDENCY_INFO}"
+
 jq -r '.licenseInfo | to_entries | .[] | "* [" + .key + "](" + .value + ")"' "${DEPENDENCY_INFO}" >"${GO_LICENSES}"

--- a/build-aux/docker/scan-js.sh
+++ b/build-aux/docker/scan-js.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 . /scripts/imports.sh
 
+validate_required_variable USER_ID
+
 scan_npm_package() {
   echo >&2 "Getting NPM dependencies for $1"
   SOURCE=$1
@@ -52,3 +54,4 @@ done
 ) | sort | uniq >/tmp/deps.txt
 
 generate_opensource /tmp/deps.txt Node.Js "${JS_DEPENDENCIES}"
+chown "${USER_ID}" -R /temp

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/bash
 set -e
 set -o pipefail
 

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+export DOCKER_BUILDKIT=1
+
 archive_dependencies() {
   tar -vf "$1" -c $2
 }
@@ -18,19 +20,16 @@ validate_required_variable BUILD_TMP
 # Go dependencies
 ######################################################################
 echo "Scanning Go dependency licenses"
-validate_required_variable GO_BUILDER
+validate_required_variable GO_IMAGE
 validate_required_variable SCRIPTS_HOME
 validate_required_variable GIT_TOKEN
 
-pushd "${BUILD_HOME}/${SCRIPTS_HOME}/cmd/go-mkopensource" >/dev/null
-GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o "${BUILD_HOME}/${SCRIPTS_HOME}/build-aux/docker/" .
-popd >/dev/null
-
 pushd "${BUILD_HOME}" >/dev/null
-DOCKER_BUILDKIT=1 docker build -f "${BUILD_HOME}/${SCRIPTS_HOME}/build-aux/docker/go_builder.dockerfile" \
+docker build \
+  -f "${BUILD_HOME}/${SCRIPTS_HOME}/build-aux/docker/go_builder.dockerfile" \
   --build-arg APPLICATION_TYPE="${APPLICATION_TYPE}" \
   --build-arg GIT_TOKEN="${GIT_TOKEN}" \
-  --build-arg GO_BUILDER="${GO_BUILDER}" \
+  --build-arg GO_IMAGE="${GO_IMAGE}" \
   --build-arg SCRIPTS_HOME="${SCRIPTS_HOME}" \
   -t "go-deps-builder" --target license_output \
   --output "${BUILD_TMP}" .

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -63,23 +63,22 @@ fi
 ######################################################################
 if [ -n "${NPM_PACKAGES}" ]; then
   echo "Scanning Node.Js dependency licenses"
-  validate_required_variable NODE_VERSION
+  validate_required_variable NODE_IMAGE
 
   archive_dependencies "${BUILD_SCRIPTS}/docker/npm_dependencies.tar" "${NPM_PACKAGES}"
 
-  pushd "${BUILD_SCRIPTS}/../cmd/js-mkopensource" >/dev/null
-  GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o "${BUILD_SCRIPTS}/docker" .
-  popd >/dev/null
-
-  pushd "${BUILD_SCRIPTS}/docker" >/dev/null
-  docker build -f js_builder.dockerfile \
-    --build-arg NODE_VERSION="${NODE_VERSION}" \
+  pushd "${BUILD_HOME}" >/dev/null
+  docker build \
+    -f "${BUILD_HOME}/${SCRIPTS_HOME}/build-aux/docker/js_builder.dockerfile" \
+    --build-arg NODE_IMAGE="${NODE_IMAGE}" \
     --build-arg APPLICATION_TYPE="${APPLICATION_TYPE}" \
     -t "js-deps-builder" \
     --target npm_dependency_scanner .
   popd >/dev/null
 
-  docker run --rm --env APPLICATION \
+  docker run --rm \
+    --env APPLICATION \
+    --env USER_ID=${UID} \
     --volume "$(realpath ${BUILD_TMP})":/temp \
     js-deps-builder /scripts/scan-js.sh
 fi

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -40,16 +40,16 @@ popd >/dev/null
 ######################################################################
 if [ -n "${PYTHON_PACKAGES}" ]; then
   echo "Scanning Python dependency licenses"
-  validate_required_variable PYTHON_BUILDER
+  validate_required_variable PYTHON_IMAGE
 
   archive_dependencies "${BUILD_SCRIPTS}/docker/python_dependencies.tar" "${PYTHON_PACKAGES}"
 
-  pushd "${BUILD_SCRIPTS}/../cmd/py-mkopensource" >/dev/null
-  GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o "${BUILD_SCRIPTS}/docker" .
-  popd >/dev/null
-
-  pushd "${BUILD_SCRIPTS}/docker" >/dev/null
-  docker build -f py_builder.dockerfile --build-arg PYTHON_BUILDER="${PYTHON_BUILDER}" -t "py-deps-builder" \
+  pushd "${BUILD_HOME}" >/dev/null
+  docker build \
+    -f "${BUILD_HOME}/${SCRIPTS_HOME}/build-aux/docker/py_builder.dockerfile" \
+    --build-arg PYTHON_IMAGE="${PYTHON_IMAGE}" \
+    --build-arg SCRIPTS_HOME="${SCRIPTS_HOME}" \
+    -t "py-deps-builder" \
     --target python_dependency_scanner .
   popd >/dev/null
 
@@ -72,6 +72,7 @@ if [ -n "${NPM_PACKAGES}" ]; then
     -f "${BUILD_HOME}/${SCRIPTS_HOME}/build-aux/docker/js_builder.dockerfile" \
     --build-arg NODE_IMAGE="${NODE_IMAGE}" \
     --build-arg APPLICATION_TYPE="${APPLICATION_TYPE}" \
+    --build-arg SCRIPTS_HOME="${SCRIPTS_HOME}" \
     -t "js-deps-builder" \
     --target npm_dependency_scanner .
   popd >/dev/null

--- a/pkg/detectlicense/validationexceptions.go
+++ b/pkg/detectlicense/validationexceptions.go
@@ -6,7 +6,11 @@ import (
 )
 
 func isAmbassadorProprietarySoftware(packageName string) bool {
-	return strings.HasPrefix(packageName, "github.com/datawire/telepresence2-proprietary/")
+	const SmartAgentRepo = "github.com/datawire/telepresence2-proprietary/"
+	const AmbassadorCloudRepo = "github.com/datawire/saas_app/"
+	const TelepresencePro = "github.com/datawire/telepresence-pro/"
+
+	return strings.HasPrefix(packageName, SmartAgentRepo) || strings.HasPrefix(packageName, AmbassadorCloudRepo) || strings.HasPrefix(packageName, TelepresencePro)
 }
 
 // knownDependencies will return a list of licenses for any dependency that has been


### PR DESCRIPTION
Ambassador Cloud build was failing because the GitHub build container was using an old version of Go  (1.15) and `go-mkopensource` uses features from `1.16`. This PR changes how binaries are build to address this problem.

There is also a change in the main script used when generating dependencies to user `/bin/bash` instead of `/bin/env bash` since some developer machines don't have the `/bin/env` binary.