### PR TITLE
Improve error messages in go scanner

### DIFF
--- a/cmd/go-mkopensource/README.md
+++ b/cmd/go-mkopensource/README.md
@@ -41,7 +41,7 @@ path.  For example, `--gotar=$HOME/Downloads/go1.17.2.tar.gz`.
 
 ### Target to describe
 
-The `--package=` flag tells `go-mkopensource` which Go packages it
+The `--package=` flag tells `go-mkopensource` which packages it
 should produce a report for.  You can either
 
 - pass it a string that you would pass to `go list` like `./...` or

--- a/cmd/go-mkopensource/README.md
+++ b/cmd/go-mkopensource/README.md
@@ -41,7 +41,7 @@ path.  For example, `--gotar=$HOME/Downloads/go1.17.2.tar.gz`.
 
 ### Target to describe
 
-The `--package=` flag tells `go-mkopensource` which packages it
+The `--package=` flag tells `go-mkopensource` which Go packages it
 should produce a report for.  You can either
 
 - pass it a string that you would pass to `go list` like `./...` or

--- a/cmd/go-mkopensource/dependency.go
+++ b/cmd/go-mkopensource/dependency.go
@@ -35,11 +35,11 @@ func GenerateDependencyList(modNames []string, modLicenses map[string]map[detect
 	}
 
 	if err := dependencyList.CheckLicenses(licenseRestriction); err != nil {
-		return dependencyList, fmt.Errorf("License validation failed: %v\n", err)
+		return dependencyList, fmt.Errorf("License validation failed for Go: %v\n", err)
 	}
 
 	if err := dependencyList.UpdateLicenseList(); err != nil {
-		return dependencyList, fmt.Errorf("Could not generate list of license URLs: %v\n", err)
+		return dependencyList, fmt.Errorf("Could not generate list of license URLs for Go: %v\n", err)
 	}
 
 	return dependencyList, nil

--- a/cmd/go-mkopensource/dependency.go
+++ b/cmd/go-mkopensource/dependency.go
@@ -9,8 +9,10 @@ import (
 )
 
 func GenerateDependencyList(modNames []string, modLicenses map[string]map[detectlicense.License]struct{},
-	modInfos map[string]*golist.Module, goVersion string, licenseRestriction detectlicense.LicenseRestriction) (dependencies.DependencyInfo, error) {
-	dependencyList := dependencies.NewDependencyInfo()
+	modInfos map[string]*golist.Module, goVersion string,
+	licenseRestriction detectlicense.LicenseRestriction) (dependencyList dependencies.DependencyInfo, errors []error) {
+	dependencyList = dependencies.NewDependencyInfo()
+	errors = []error{}
 
 	for _, modKey := range modNames {
 		ambassadorProprietary := isAmbassadorProprietary(modLicenses[modKey])
@@ -28,21 +30,21 @@ func GenerateDependencyList(modNames []string, modLicenses map[string]map[detect
 
 		for license := range modLicenses[modKey] {
 			dependencyDetails.Licenses = append(dependencyDetails.Licenses, license.Name)
+
+			if err := dependencies.CheckLicenseRestrictions(dependencyDetails, license.Name, licenseRestriction); err != nil {
+				errors = append(errors, err)
+			}
 		}
 		sort.Strings(dependencyDetails.Licenses)
 
 		dependencyList.Dependencies = append(dependencyList.Dependencies, dependencyDetails)
 	}
 
-	if err := dependencyList.CheckLicenses(licenseRestriction); err != nil {
-		return dependencyList, fmt.Errorf("License validation failed for Go: %v\n", err)
-	}
-
 	if err := dependencyList.UpdateLicenseList(); err != nil {
-		return dependencyList, fmt.Errorf("Could not generate list of license URLs for Go: %v\n", err)
+		errors = append(errors, fmt.Errorf("Could not generate list of license URLs: %v\n", err))
 	}
 
-	return dependencyList, nil
+	return dependencyList, errors
 }
 
 func getDependencyName(modVal *golist.Module) string {

--- a/cmd/go-mkopensource/dependency_test.go
+++ b/cmd/go-mkopensource/dependency_test.go
@@ -22,19 +22,19 @@ var (
 func TestGenerateDependencyListWhenLicenseIsAllowed(t *testing.T) {
 	licenses := map[string]map[License]struct{}{modNames[0]: {BSD1: {}}}
 
-	_, err := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
-	require.NoError(t, err)
+	_, errors := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
+	require.Empty(t, errors)
 
-	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, AmbassadorServers)
-	require.NoError(t, err)
+	_, errors = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, AmbassadorServers)
+	require.Empty(t, errors)
 }
 
 func TestGenerateDependencyListWhenLicenseIsForbidden(t *testing.T) {
 	licenses := map[string]map[License]struct{}{modNames[0]: {AGPL1Only: {}}}
 
-	_, err := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
-	require.Error(t, err)
+	_, errors := main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, Unrestricted)
+	require.NotEmptyf(t, errors, "Expected at least one error but got none")
 
-	_, err = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, AmbassadorServers)
-	require.Error(t, err)
+	_, errors = main.GenerateDependencyList(modNames, licenses, modInfos, goVersion, AmbassadorServers)
+	require.NotEmptyf(t, errors, "Expected at least one error but got none")
 }

--- a/cmd/go-mkopensource/explain.go
+++ b/cmd/go-mkopensource/explain.go
@@ -49,7 +49,9 @@ var errCategoryExplanations = map[string]string{
 		  dependency
 
 		- License information can't be identified: Add an entry to 
-          knownDependencies().`,
+          hardcodedGoDependencies, hardcodedPythonDependencies 
+          or hardcodedJsDependencies depending on the dependency that
+          was not identified.`,
 
 	internalUsageOnly: `This means that a dependency uses a license that is not allowed for use
 		on customer servers. Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 

--- a/cmd/go-mkopensource/main.go
+++ b/cmd/go-mkopensource/main.go
@@ -122,7 +122,7 @@ func main() {
 		os.Exit(int(InvalidArgumentsError))
 	}
 	if err := Main(args); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%s: fatal: %v\n", os.Args[0], err)
+		_, _ = fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(int(DependencyGenerationError))
 	}
 }

--- a/cmd/go-mkopensource/main.go
+++ b/cmd/go-mkopensource/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/datawire/go-mkopensource/pkg/scanningerrors"
 	"io"
 	"os"
 	"os/exec"
@@ -284,7 +285,7 @@ func Main(args *CLIArgs) error {
 		}
 	}
 	if len(licErrs) > 0 {
-		return ExplainErrors(licErrs)
+		return scanningerrors.ExplainErrors(licErrs)
 	}
 
 	// Group packages by module & collect module info
@@ -342,7 +343,7 @@ func Main(args *CLIArgs) error {
 	case "txt":
 		readme, generationErr := generateOutput(args.Package, args.OutputFormat, args.OutputType, licenseRestriction, mainMods, mainLibPkgs, mainCmdPkgs, modNames, modLicenses, modInfos, goVersion)
 		if generationErr != nil {
-			return ExplainErrors([]error{generationErr})
+			return scanningerrors.ExplainErrors([]error{generationErr})
 		}
 
 		if _, err := readme.WriteTo(os.Stdout); err != nil {
@@ -352,7 +353,7 @@ func Main(args *CLIArgs) error {
 		// Build a listing of all files to go in to the tarball
 		readme, generationErr := generateOutput(args.Package, args.OutputFormat, markdownOutputType, licenseRestriction, mainMods, mainLibPkgs, mainCmdPkgs, modNames, modLicenses, modInfos, goVersion)
 		if generationErr != nil {
-			return ExplainErrors([]error{generationErr})
+			return scanningerrors.ExplainErrors([]error{generationErr})
 		}
 
 		tarFiles := make(map[string][]byte)
@@ -444,7 +445,7 @@ func generateOutput(packages string, outputFormat string, outputType string, lic
 
 	if outputFormat == "tar" {
 		output.WriteString("\n")
-		output.WriteString(wordwrap(0, 75, "The appropriate license notices and source code are in correspondingly named directories.") + "\n")
+		output.WriteString(scanningerrors.Wordwrap(0, 75, "The appropriate license notices and source code are in correspondingly named directories.") + "\n")
 	}
 	return output, nil
 }
@@ -456,27 +457,27 @@ func markdownHeader(packages string, mainMods map[string]struct{}, readme *bytes
 			modnames = append(modnames, modname)
 		}
 		if len(mainMods) == 1 {
-			readme.WriteString(wordwrap(0, 75, fmt.Sprintf("The Go module %q incorporates the following Free and Open Source software:", modnames[0])) + "\n")
+			readme.WriteString(scanningerrors.Wordwrap(0, 75, fmt.Sprintf("The Go module %q incorporates the following Free and Open Source software:", modnames[0])) + "\n")
 		} else {
 			sort.Strings(modnames)
-			readme.WriteString(wordwrap(0, 75, fmt.Sprintf("The Go modules %q incorporate the following Free and Open Source software:", modnames)) + "\n")
+			readme.WriteString(scanningerrors.Wordwrap(0, 75, fmt.Sprintf("The Go modules %q incorporate the following Free and Open Source software:", modnames)) + "\n")
 		}
 		return
 	}
 
 	if len(mainLibPkgs) == 0 {
 		if len(mainCmdPkgs) == 1 {
-			readme.WriteString(wordwrap(0, 75, fmt.Sprintf("The program %q incorporates the following Free and Open Source software:", path.Base(mainCmdPkgs[0]))) + "\n")
+			readme.WriteString(scanningerrors.Wordwrap(0, 75, fmt.Sprintf("The program %q incorporates the following Free and Open Source software:", path.Base(mainCmdPkgs[0]))) + "\n")
 		} else {
-			readme.WriteString(wordwrap(0, 75, fmt.Sprintf("The programs %q incorporate the following Free and Open Source software:", packages)) + "\n")
+			readme.WriteString(scanningerrors.Wordwrap(0, 75, fmt.Sprintf("The programs %q incorporate the following Free and Open Source software:", packages)) + "\n")
 		}
 		return
 	}
 
 	if len(mainLibPkgs) == 1 {
-		readme.WriteString(wordwrap(0, 75, fmt.Sprintf("The Go package %q incorporates the following Free and Open Source software:", mainLibPkgs[0])) + "\n")
+		readme.WriteString(scanningerrors.Wordwrap(0, 75, fmt.Sprintf("The Go package %q incorporates the following Free and Open Source software:", mainLibPkgs[0])) + "\n")
 	} else {
-		readme.WriteString(wordwrap(0, 75, fmt.Sprintf("The Go packages %q incorporate the following Free and Open Source software:", packages)) + "\n")
+		readme.WriteString(scanningerrors.Wordwrap(0, 75, fmt.Sprintf("The Go packages %q incorporate the following Free and Open Source software:", packages)) + "\n")
 	}
 }
 

--- a/cmd/go-mkopensource/main.go
+++ b/cmd/go-mkopensource/main.go
@@ -280,7 +280,7 @@ func Main(args *CLIArgs) error {
 	for _, pkgName := range pkgNames {
 		pkgLicenses[pkgName], err = detectlicense.DetectLicenses(pkgName, pkgVersions[pkgName], pkgFiles[pkgName])
 		if err != nil {
-			err = fmt.Errorf(`package %q: %w`, pkgName, err)
+			err = fmt.Errorf(`Go package %q: %w`, pkgName, err)
 			licErrs = append(licErrs, err)
 		}
 	}

--- a/cmd/go-mkopensource/main_test.go
+++ b/cmd/go-mkopensource/main_test.go
@@ -166,26 +166,31 @@ func TestSuccessfulJsonOutput(t *testing.T) {
 
 func TestErrorScenarios(t *testing.T) {
 	testCases := []struct {
+		testName       string
 		testData       string
 		packagesFlag   string
 		outputTypeFlag string
 	}{
 		{
+			testName:       "testdata/00-intern-old",
 			testData:       "testdata/00-intern-old",
 			packagesFlag:   "mod",
 			outputTypeFlag: "full",
 		},
 		{
+			testName:       "Multiple errors",
 			testData:       "testdata/03-multierror",
 			packagesFlag:   "mod",
 			outputTypeFlag: "full",
 		},
 		{
+			testName:       "Forbidden license",
 			testData:       "testdata/07-forbidden-license",
 			packagesFlag:   "mod",
 			outputTypeFlag: "full",
 		},
 		{
+			testName:       "License not allowed on distributed applications",
 			testData:       "testdata/08-allowed-for-internal-use-only",
 			packagesFlag:   "mod",
 			outputTypeFlag: "full",
@@ -195,7 +200,7 @@ func TestErrorScenarios(t *testing.T) {
 	workingDir := getWorkingDir(t)
 
 	for _, testCase := range testCases {
-		t.Run(testCase.testData, func(t *testing.T) {
+		t.Run(testCase.testName, func(t *testing.T) {
 			defer func() {
 				require.NoError(t, os.Chdir(workingDir))
 			}()

--- a/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
@@ -1,5 +1,5 @@
 1 license-detection error:
- 1. Go package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
+ 1. Package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what
     the license is.  (This is a good thing, because it is reminding you

--- a/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
@@ -1,5 +1,5 @@
 1 license-detection error:
- 1. package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
+ 1. Go package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what
     the license is.  (This is a good thing, because it is reminding you

--- a/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
@@ -12,7 +12,9 @@
     dependency
 
     - License information can't be identified: Add an entry to
-    knownDependencies().
+    hardcodedGoDependencies, hardcodedPythonDependencies or
+    hardcodedJsDependencies depending on the dependency that was not
+    identified.
 
     For github.com/josharian/intern in particular, this probably means
     that you are depending on an old version; upgrading to intern

--- a/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
@@ -5,9 +5,14 @@
     the license is.  (This is a good thing, because it is reminding you
     to check the license of libraries before using them.)
 
-    You need to update the
-    "github.com/datawire/go-mkopensource/pkg/detectlicense/licenses.go"
-    file to correctly detect the license.
+    Some possible causes for this issue are:
+
+    - Dependency is proprietary Ambassador Labs software: Update
+    function IsAmbassadorProprietarySoftware() to correctly identify the
+    dependency
+
+    - License information can't be identified: Add an entry to
+    knownDependencies().
 
     For github.com/josharian/intern in particular, this probably means
     that you are depending on an old version; upgrading to intern

--- a/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
@@ -1,24 +1,29 @@
-3 license-approval errors:
+2 license-approval errors:
  1. package "example.com/apache-patent/a": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
  2. package "example.com/apache-patent/b": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
- 3. package "example.com/cc-sa": has an unacceptable license for use by Ambassador Labs (Creative Commons Attribution Share Alike 4.0 International)
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker objects to what it sees.  This
     may because of a bug in the checker
     (github.com/datawire/go-mkopensource) that you need to go fix, or it
     may be because of an actual license issue that prevents you from
     being allowed to use a package, and you need to find an alternative.
-2 license-detection errors:
- 1. package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
- 2. package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
+3 license-detection errors:
+ 1. package "example.com/cc-sa": has an unacceptable license for use by Ambassador Labs (Creative Commons Attribution Share Alike 4.0 International)
+ 2. package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
+ 3. package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what
     the license is.  (This is a good thing, because it is reminding you
     to check the license of libraries before using them.)
 
-    You need to update the
-    "github.com/datawire/go-mkopensource/pkg/detectlicense/licenses.go"
-    file to correctly detect the license.
+    Some possible causes for this issue are:
+
+    - Dependency is proprietary Ambassador Labs software: Update
+    function IsAmbassadorProprietarySoftware() to correctly identify
+    the dependency
+
+    - License information can't be identified: Add an entry to
+    knownDependencies().
 
     For github.com/josharian/intern in particular, this probably means
     that you are depending on an old version; upgrading to intern

--- a/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
@@ -1,6 +1,14 @@
+1 intended-usage errors:
+ 1. Dependency 'example.com/cc-sa@(modified)' uses license 'Creative Commons Attribution Share Alike 4.0 International' which is not allowed on applications that run on customer machines.
+    To solve this error, replace the dependency with another that uses
+    an acceptable license.
+
+    Refer to
+    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
+    for more details.
 2 license-approval errors:
- 1. Go package "example.com/apache-patent/a": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
- 2. Go package "example.com/apache-patent/b": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
+ 1. Package "example.com/apache-patent/a": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
+ 2. Package "example.com/apache-patent/b": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker objects to what it sees.  This
     may because of a bug in the checker
@@ -8,8 +16,8 @@
     may be because of an actual license issue that prevents you from
     being allowed to use a package, and you need to find an alternative.
 2 license-detection errors:
- 1. Go package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
- 2. Go package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
+ 1. Package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
+ 2. Package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what
     the license is.  (This is a good thing, because it is reminding you

--- a/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
@@ -7,10 +7,9 @@
     (github.com/datawire/go-mkopensource) that you need to go fix, or it
     may be because of an actual license issue that prevents you from
     being allowed to use a package, and you need to find an alternative.
-3 license-detection errors:
- 1. package "example.com/cc-sa": has an unacceptable license for use by Ambassador Labs (Creative Commons Attribution Share Alike 4.0 International)
- 2. package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
- 3. package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
+2 license-detection errors:
+ 1. package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
+ 2. package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what
     the license is.  (This is a good thing, because it is reminding you
@@ -19,11 +18,13 @@
     Some possible causes for this issue are:
 
     - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify
-    the dependency
+    function IsAmbassadorProprietarySoftware() to correctly identify the
+    dependency
 
     - License information can't be identified: Add an entry to
-    knownDependencies().
+    hardcodedGoDependencies, hardcodedPythonDependencies or
+    hardcodedJsDependencies depending on the dependency that was not
+    identified.
 
     For github.com/josharian/intern in particular, this probably means
     that you are depending on an old version; upgrading to intern

--- a/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
@@ -1,6 +1,6 @@
 2 license-approval errors:
- 1. package "example.com/apache-patent/a": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
- 2. package "example.com/apache-patent/b": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
+ 1. Go package "example.com/apache-patent/a": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
+ 2. Go package "example.com/apache-patent/b": the Apache license contains a patent-grant, but there's a separate PATENTS file; something hokey is going on
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker objects to what it sees.  This
     may because of a bug in the checker
@@ -8,8 +8,8 @@
     may be because of an actual license issue that prevents you from
     being allowed to use a package, and you need to find an alternative.
 2 license-detection errors:
- 1. package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
- 2. package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
+ 1. Go package "example.com/gpl": unknown SPDX identifier "GPL-3.0-or-later-with-some-non-standard-exception"
+ 2. Go package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what
     the license is.  (This is a good thing, because it is reminding you

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
@@ -1,5 +1,5 @@
 1 license-forbidden error:
- 1. License validation failed for Go: Dependency 'example.com/agpl' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
+ 1. License validation failed for Go: Dependency 'example.com/agpl@(modified)' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
 
     This means that a dependency uses a license that is not allowed for
     use in Ambassador Labs software. Refer to

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
@@ -1,10 +1,8 @@
 1 license-forbidden error:
- 1. License validation failed for Go: Dependency 'example.com/agpl@(modified)' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
-
-    This means that a dependency uses a license that is not allowed for
-    use in Ambassador Labs software. Refer to
-    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
-    for more details.
-
+ 1. Dependency 'example.com/agpl@(modified)' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
     To solve this error, replace the dependency with another that uses
     an acceptable license.
+
+    Refer to
+    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
+    for more details.

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
@@ -1,5 +1,5 @@
 1 license-forbidden error:
- 1. License validation failed: Dependency 'example.com/agpl' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
+ 1. License validation failed for Go: Dependency 'example.com/agpl' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
 
     This means that a dependency uses a license that is not allowed for
     use in Ambassador Labs software. Refer to

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
@@ -7,4 +7,4 @@
     for more details.
 
     To solve this error, replace the dependency with another that uses
-    an acceptable license
+    an acceptable license.

--- a/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/07-forbidden-license/expected_err.txt
@@ -1,2 +1,10 @@
-License validation failed: Dependency 'example.com/agpl' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
-Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 for more details.
+1 license-forbidden error:
+ 1. License validation failed: Dependency 'example.com/agpl' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
+
+    This means that a dependency uses a license that is not allowed for
+    use in Ambassador Labs software. Refer to
+    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
+    for more details.
+
+    To solve this error, replace the dependency with another that uses
+    an acceptable license

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
@@ -1,2 +1,18 @@
-License validation failed: Dependency 'example.com/gpl' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
-Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 for more details.
+1 license-detection error:
+ 1. License validation failed: Dependency 'example.com/gpl' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
+
+    This probably means that you added or upgraded a dependency, and the
+    automated opensource-license-checker can't confidently detect what
+    the license is.  (This is a good thing, because it is reminding you
+    to check the license of libraries before using them.)
+
+    Some possible causes for this issue are:
+
+    - Dependency is proprietary Ambassador Labs software: Update
+    function IsAmbassadorProprietarySoftware() to correctly identify the
+    dependency
+
+    - License information can't be identified: Add an entry to
+    hardcodedGoDependencies, hardcodedPythonDependencies or
+    hardcodedJsDependencies depending on the dependency that was not
+    identified.

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
@@ -1,10 +1,8 @@
 1 intended-usage error:
- 1. License validation failed for Go: Dependency 'example.com/gpl@(modified)' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
-
-    This means that a dependency uses a license that is not allowed for
-    use on customer machines. Refer to
-    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
-    for more details.
-
+ 1. Dependency 'example.com/gpl@(modified)' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
     To solve this error, replace the dependency with another that uses
     an acceptable license.
+
+    Refer to
+    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
+    for more details.

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
@@ -1,8 +1,8 @@
 1 intended-usage error:
- 1. License validation failed for Go: Dependency 'example.com/gpl' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
+ 1. License validation failed for Go: Dependency 'example.com/gpl@(modified)' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
 
     This means that a dependency uses a license that is not allowed for
-    use on customer servers. Refer to
+    use on customer machines. Refer to
     https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
     for more details.
 

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
@@ -1,18 +1,10 @@
-1 license-detection error:
+1 intended-usage error:
  1. License validation failed for Go: Dependency 'example.com/gpl' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
 
-    This probably means that you added or upgraded a dependency, and the
-    automated opensource-license-checker can't confidently detect what
-    the license is.  (This is a good thing, because it is reminding you
-    to check the license of libraries before using them.)
+    This means that a dependency uses a license that is not allowed for
+    use on customer servers. Refer to
+    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
+    for more details.
 
-    Some possible causes for this issue are:
-
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
-
-    - License information can't be identified: Add an entry to
-    hardcodedGoDependencies, hardcodedPythonDependencies or
-    hardcodedJsDependencies depending on the dependency that was not
-    identified.
+    To solve this error, replace the dependency with another that uses
+    an acceptable license.

--- a/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/08-allowed-for-internal-use-only/expected_err.txt
@@ -1,5 +1,5 @@
 1 license-detection error:
- 1. License validation failed: Dependency 'example.com/gpl' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
+ 1. License validation failed for Go: Dependency 'example.com/gpl' uses license 'GNU General Public License v1.0 or later' which is not allowed on applications that run on customer machines.
 
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what

--- a/cmd/py-mkopensource/main_test.go
+++ b/cmd/py-mkopensource/main_test.go
@@ -124,14 +124,14 @@ func TestForbiddenLicenses(t *testing.T) {
 			"./testdata/gpl-license/dependency_list.txt",
 			markdownOutputType,
 			externalApplication,
-			"Dependency 'docutils' uses license 'GNU General Public License v3.0 or later' which is not allowed on applications that run on customer machines.",
+			"Dependency 'docutils@0.17.1' uses license 'GNU General Public License v3.0 or later' which is not allowed on applications that run on customer machines.",
 		},
 		{
 			"GPL licenses are forbidden for external use - JSON format",
 			"./testdata/gpl-license/dependency_list.txt",
 			jsonOutputType,
 			externalApplication,
-			"Dependency 'docutils' uses license 'GNU General Public License v3.0 or later' which is not allowed on applications that run on customer machines.",
+			"Dependency 'docutils@0.17.1' uses license 'GNU General Public License v3.0 or later' which is not allowed on applications that run on customer machines.",
 		},
 		{
 			"AGPL licenses are forbidden for internal use - Markdown format",

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.17
 
 require (
 	github.com/datawire/dlib v1.2.5-0.20211116212847-0316f8d7af2b
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -120,15 +120,12 @@ func (d *DependencyInfo) CheckLicenses(licenseRestriction LicenseRestriction) er
 			}
 
 			if license.Restriction == Forbidden {
-				return fmt.Errorf("Dependency '%s' uses license '%s' which is forbidden.\n"+
-					"Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 "+
-					"for more details.", dependency.Name, license.Name)
+				return fmt.Errorf("Dependency '%s' uses license '%s' which is forbidden.", dependency.Name, license.Name)
 			}
 
 			if license.Restriction < licenseRestriction {
-				return fmt.Errorf("Dependency '%s' uses license '%s' which is not allowed on applications that run on customer machines.\n"+
-					"Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 "+
-					"for more details.", dependency.Name, license.Name)
+				return fmt.Errorf("Dependency '%s' uses license '%s' which is not allowed on applications that run on customer machines.",
+					dependency.Name, license.Name)
 			}
 		}
 	}

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -114,21 +114,29 @@ func (d *DependencyInfo) CheckLicenses(licenseRestriction LicenseRestriction) er
 
 	for _, dependency := range d.Dependencies {
 		for _, licenseName := range dependency.Licenses {
-			license, err := getLicenseFromName(licenseName)
+			err := CheckLicenseRestrictions(dependency, licenseName, licenseRestriction)
 			if err != nil {
 				return err
 			}
-
-			if license.Restriction == Forbidden {
-				return fmt.Errorf("Dependency '%s@%s' uses license '%s' which is forbidden.", dependency.Name,
-					dependency.Version, license.Name)
-			}
-
-			if license.Restriction < licenseRestriction {
-				return fmt.Errorf("Dependency '%s@%s' uses license '%s' which is not allowed on applications that run on customer machines.",
-					dependency.Name, dependency.Version, license.Name)
-			}
 		}
+	}
+	return nil
+}
+
+func CheckLicenseRestrictions(dependency Dependency, licenseName string, licenseRestriction LicenseRestriction) error {
+	license, err := getLicenseFromName(licenseName)
+	if err != nil {
+		return err
+	}
+
+	if license.Restriction == Forbidden {
+		return fmt.Errorf("Dependency '%s@%s' uses license '%s' which is forbidden.", dependency.Name,
+			dependency.Version, license.Name)
+	}
+
+	if license.Restriction < licenseRestriction {
+		return fmt.Errorf("Dependency '%s@%s' uses license '%s' which is not allowed on applications that run on customer machines.",
+			dependency.Name, dependency.Version, license.Name)
 	}
 	return nil
 }

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -120,12 +120,13 @@ func (d *DependencyInfo) CheckLicenses(licenseRestriction LicenseRestriction) er
 			}
 
 			if license.Restriction == Forbidden {
-				return fmt.Errorf("Dependency '%s' uses license '%s' which is forbidden.", dependency.Name, license.Name)
+				return fmt.Errorf("Dependency '%s@%s' uses license '%s' which is forbidden.", dependency.Name,
+					dependency.Version, license.Name)
 			}
 
 			if license.Restriction < licenseRestriction {
-				return fmt.Errorf("Dependency '%s' uses license '%s' which is not allowed on applications that run on customer machines.",
-					dependency.Name, license.Name)
+				return fmt.Errorf("Dependency '%s@%s' uses license '%s' which is not allowed on applications that run on customer machines.",
+					dependency.Name, dependency.Version, license.Name)
 			}
 		}
 	}

--- a/pkg/dependencies/dependencyinfo_test.go
+++ b/pkg/dependencies/dependencyinfo_test.go
@@ -252,12 +252,12 @@ func TestCheckLicensesValidatesForbiddenLicensesCorrectly(t *testing.T) {
 			detectlicense.AmbassadorServers,
 		},
 		{
-			"Forbidden licenses are not allowed on customer servers",
+			"Forbidden licenses are not allowed on customer machines",
 			forbiddenLicensesOnly,
 			detectlicense.Unrestricted,
 		},
 		{
-			"Restricted licenses are not OK on customer servers",
+			"Restricted licenses are not OK on customer machines",
 			licensesForAmbassadorServersOnly,
 			detectlicense.Unrestricted,
 		},
@@ -267,7 +267,7 @@ func TestCheckLicensesValidatesForbiddenLicensesCorrectly(t *testing.T) {
 			detectlicense.Unrestricted,
 		},
 		{
-			"Mix of licenses without forbidden is rejected on customer servers",
+			"Mix of licenses without forbidden is rejected on customer machines",
 			mixOfLicensesWithoutForbidden,
 			detectlicense.Unrestricted,
 		},

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -347,7 +347,7 @@ specific language governing permissions and limitations under the License.      
 	xzPublicDomain = `Licensing of github.com/xi2/xz
 ==============================
 
-    This Go package is a modified version of
+    This package is a modified version of
 
         XZ Embedded  <http://tukaani.org/xz/embedded.html>
 

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -18,12 +18,11 @@ const (
 )
 
 type License struct {
-	Name           string
-	NoticeFile     bool               // are NOTICE files "a thing" for this license?
-	WeakCopyleft   bool               // requires that library to be open-source
-	StrongCopyleft bool               // requires the resulting program to be open-source
-	URL            string             // Location of the license description
-	Restriction    LicenseRestriction // Where is this license allowed
+	Name         string
+	NoticeFile   bool               // are NOTICE files "a thing" for this license?
+	WeakCopyleft bool               // requires that library to be open-source
+	URL          string             // Location of the license description
+	Restriction  LicenseRestriction // Where is this license allowed
 }
 
 //nolint:gochecknoglobals // Would be 'const'.
@@ -50,7 +49,7 @@ var (
 	CcBy40 = License{Name: "Creative Commons Attribution 4.0 International",
 		URL: "https://spdx.org/licenses/CC-BY-4.0.html", Restriction: AmbassadorServers}
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
-		StrongCopyleft: true, URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html", Restriction: AmbassadorServers}
+		URL: "https://spdx.org/licenses/CC-BY-SA-4.0.html", Restriction: AmbassadorServers}
 	Cc010 = License{Name: "Creative Commons Zero v1.0 Universal",
 		URL: "https://spdx.org/licenses/CC0-1.0.html", Restriction: Unrestricted}
 	EPL10 = License{Name: "Eclipse Public License 1.0", URL: "https://spdx.org/licenses/EPL-1.0.html",
@@ -63,7 +62,7 @@ var (
 		URL: "https://spdx.org/licenses/GPL-2.0-only.html", Restriction: AmbassadorServers}
 	GPL2OrLater = License{Name: "GNU General Public License v2.0 or later",
 		URL: "https://spdx.org/licenses/GPL-2.0-or-later.html", Restriction: AmbassadorServers}
-	GPL3Only = License{Name: "GNU General Public License v3.0 only", StrongCopyleft: true,
+	GPL3Only = License{Name: "GNU General Public License v3.0 only",
 		URL: "https://spdx.org/licenses/GPL-3.0.html", Restriction: AmbassadorServers}
 	GPL3OrLater = License{Name: "GNU General Public License v3.0 or later",
 		URL: "https://spdx.org/licenses/GPL-3.0-or-later.html", Restriction: AmbassadorServers}

--- a/pkg/detectlicense/validationexceptions.go
+++ b/pkg/detectlicense/validationexceptions.go
@@ -12,13 +12,13 @@ func isAmbassadorProprietarySoftware(packageName string) bool {
 // knownDependencies will return a list of licenses for any dependency that has been
 // hardcoded due to the difficulty to parse the license file(s).
 func knownDependencies(dependencyName string, dependencyVersion string) (licenses []License, ok bool) {
-	hardcodedDependencies := map[string][]License{
+	hardcodedGoDependencies := map[string][]License{
 		"github.com/josharian/intern@v1.0.1-0.20211109044230-42b52b674af5":       {MIT},
 		"github.com/dustin/go-humanize@v1.0.0":                                   {MIT},
 		"github.com/garyburd/redigo/internal@v0.0.0-20150301180006-535138d7bcd7": {Apache2},
 		"github.com/garyburd/redigo/redis@v0.0.0-20150301180006-535138d7bcd7":    {Apache2},
 	}
 
-	licenses, ok = hardcodedDependencies[fmt.Sprintf("%s@%s", dependencyName, dependencyVersion)]
+	licenses, ok = hardcodedGoDependencies[fmt.Sprintf("%s@%s", dependencyName, dependencyVersion)]
 	return
 }

--- a/pkg/scanningerrors/explain.go
+++ b/pkg/scanningerrors/explain.go
@@ -24,7 +24,7 @@ func categorizeError(errStr string) string {
 		return licenseDetection
 	case strings.Contains(errStr, "is forbidden"):
 		return licenseForbidden
-	case strings.Contains(errStr, "should not be used since application will run on customer servers"):
+	case strings.Contains(errStr, "which is not allowed on applications"):
 		return internalUsageOnly
 	default:
 		return licenseDetection
@@ -56,16 +56,16 @@ var errCategoryExplanations = map[string]string{
           was not identified.`,
 
 	internalUsageOnly: `This means that a dependency uses a license that is not allowed for use
-		on customer servers. Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 
+		on customer machines. Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 
         for more details.
 
-        To solve this error, replace the dependency with another that uses an acceptable license`,
+        To solve this error, replace the dependency with another that uses an acceptable license.`,
 
 	licenseForbidden: `This means that a dependency uses a license that is not allowed for use
 		in Ambassador Labs software. Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 
         for more details.
 
-        To solve this error, replace the dependency with another that uses an acceptable license`,
+        To solve this error, replace the dependency with another that uses an acceptable license.`,
 }
 
 func ExplainErrors(errs []error) error {

--- a/pkg/scanningerrors/explain.go
+++ b/pkg/scanningerrors/explain.go
@@ -55,17 +55,15 @@ var errCategoryExplanations = map[string]string{
           or hardcodedJsDependencies depending on the dependency that
           was not identified.`,
 
-	internalUsageOnly: `This means that a dependency uses a license that is not allowed for use
-		on customer machines. Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 
-        for more details.
+	internalUsageOnly: `To solve this error, replace the dependency with another that uses an acceptable license.
 
-        To solve this error, replace the dependency with another that uses an acceptable license.`,
+        Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 
+        for more details.`,
 
-	licenseForbidden: `This means that a dependency uses a license that is not allowed for use
-		in Ambassador Labs software. Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 
-        for more details.
+	licenseForbidden: `To solve this error, replace the dependency with another that uses an acceptable license.
 
-        To solve this error, replace the dependency with another that uses an acceptable license.`,
+        Refer to https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173 
+        for more details.`,
 }
 
 func ExplainErrors(errs []error) error {

--- a/pkg/scanningerrors/explain.go
+++ b/pkg/scanningerrors/explain.go
@@ -92,7 +92,7 @@ func ExplainErrors(errs []error) error {
 		}
 		for i, errStr := range errStrs {
 			_, _ = fmt.Fprintf(msg, " %d. %s\n", i+1, errStr)
-			if errStr == `Go package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)` {
+			if errStr == `Package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)` {
 				explanation += `
 
 					For github.com/josharian/intern in particular, this probably

--- a/pkg/scanningerrors/explain.go
+++ b/pkg/scanningerrors/explain.go
@@ -1,6 +1,6 @@
 // -*- fill-column: 100 -*-
 
-package main
+package scanningerrors
 
 import (
 	"errors"
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	licenseApproval   string = "license-approval"
+	licenseIssue      string = "license-approval"
 	licenseDetection  string = "license-detection"
 	internalUsageOnly string = "intended-usage"
 	licenseForbidden  string = "license-forbidden"
@@ -19,7 +19,9 @@ const (
 func categorizeError(errStr string) string {
 	switch {
 	case strings.Contains(errStr, "something hokey is going on"):
-		return licenseApproval
+		return licenseIssue
+	case strings.Contains(errStr, "is missing a license identifier"):
+		return licenseDetection
 	case strings.Contains(errStr, "is forbidden"):
 		return licenseForbidden
 	case strings.Contains(errStr, "should not be used since application will run on customer servers"):
@@ -31,7 +33,7 @@ func categorizeError(errStr string) string {
 
 var errCategoryExplanations = map[string]string{
 
-	licenseApproval: `This probably means that you added or upgraded a dependency, and the
+	licenseIssue: `This probably means that you added or upgraded a dependency, and the
 		automated opensource-license-checker objects to what it sees.  This may because of a
 		bug in the checker (github.com/datawire/go-mkopensource) that you need to go fix, or
 		it may be because of an actual license issue that prevents you from being allowed to
@@ -101,7 +103,7 @@ func ExplainErrors(errs []error) error {
 					resolve this.`
 			}
 		}
-		_, _ = fmt.Fprintln(msg, wordwrap(4, 72, explanation))
+		_, _ = fmt.Fprintln(msg, Wordwrap(4, 72, explanation))
 	}
 	return errors.New(strings.TrimRight(msg.String(), "\n"))
 }

--- a/pkg/scanningerrors/explain.go
+++ b/pkg/scanningerrors/explain.go
@@ -94,7 +94,7 @@ func ExplainErrors(errs []error) error {
 		}
 		for i, errStr := range errStrs {
 			_, _ = fmt.Fprintf(msg, " %d. %s\n", i+1, errStr)
-			if errStr == `package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)` {
+			if errStr == `Go package "github.com/josharian/intern": could not identify a license for all sources (had no global LICENSE file)` {
 				explanation += `
 
 					For github.com/josharian/intern in particular, this probably

--- a/pkg/scanningerrors/wordwrap.go
+++ b/pkg/scanningerrors/wordwrap.go
@@ -1,4 +1,4 @@
-package main
+package scanningerrors
 
 import (
 	"strings"
@@ -20,7 +20,7 @@ func indexWordSep(str string) int {
 	return -1
 }
 
-func wordwrap(indent, width int, str string) string {
+func Wordwrap(indent, width int, str string) string {
 	// 1. Tokenize the input
 	var words []string
 	str = strings.TrimLeft(str, whitespace)

--- a/pkg/scanningerrors/wordwrap_test.go
+++ b/pkg/scanningerrors/wordwrap_test.go
@@ -1,4 +1,4 @@
-package main
+package scanningerrors
 
 import (
 	"testing"
@@ -64,7 +64,7 @@ func TestWordWrap(t *testing.T) {
 	for tcName, tcData := range testcases {
 		tcData := tcData
 		t.Run(tcName, func(t *testing.T) {
-			actualOutput := wordwrap(
+			actualOutput := Wordwrap(
 				tcData.InputIndent,
 				tcData.InputWidth,
 				tcData.InputString)


### PR DESCRIPTION
Python and Js scanners were not using the same logic as Go scanner when an error was found, which made it difficult to figure out what was happening.

I've updated Python and Js scanner to use `ExplainErrors()` to generate an error message similar to `go-mkopensource`

Also, logic for checking if a license was strong copyleft was removed since both AGPL and GPL are strong copyleft but they have different restrictions. This validation is now based on the check for how the app will be used (SAAS vs distributed), which is already being done.