### PR TITLE
Better error handling in Python scanner

### DIFF
--- a/cmd/py-mkopensource/main.go
+++ b/cmd/py-mkopensource/main.go
@@ -291,7 +291,7 @@ func main() {
 	}
 
 	if err := Main(*cliArgs.outputType, *cliArgs.applicationType, os.Stdin, os.Stdout); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(int(DependencyGenerationError))
 	}
 }

--- a/cmd/py-mkopensource/main.go
+++ b/cmd/py-mkopensource/main.go
@@ -291,7 +291,7 @@ func main() {
 	}
 
 	if err := Main(*cliArgs.outputType, *cliArgs.applicationType, os.Stdin, os.Stdout); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, err.Error())
+		_, _ = fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(int(DependencyGenerationError))
 	}
 }

--- a/cmd/py-mkopensource/main.go
+++ b/cmd/py-mkopensource/main.go
@@ -24,76 +24,78 @@ type tuple struct {
 	License string
 }
 
-func parseLicenses(name, version, license string) map[License]struct{} {
-	override, ok := map[tuple][]License{
-		// These are packages that don't have sufficient metadata to get
-		// the license normally.  Either the license isn't specified in
-		// the metadata, or the license string that is specified is
-		// ambiguous (for example: "BSD" is too ambiguous, which variant
-		// of the BSD license is it?).  We pin the exact versions so
-		// that a human has to go make sure that the license didn't
-		// change when upgrading.
-		{"Babel", "2.8.0", "BSD"}:                      {BSD3},
-		{"CacheControl", "0.12.6", "UNKNOWN"}:          {Apache2},
-		{"CacheControl", "0.12.10", "UNKNOWN"}:         {Apache2},
-		{"Click", "7.0", "BSD"}:                        {BSD3},
-		{"Flask", "1.0.2", "BSD"}:                      {BSD3},
-		{"GitPython", "3.1.8", "UNKNOWN"}:              {BSD3},
-		{"GitPython", "3.1.11", "UNKNOWN"}:             {BSD3},
-		{"Jinja2", "2.10.1", "BSD"}:                    {BSD3},
-		{"Pygments", "2.7.1", "BSD License"}:           {BSD2},
-		{"Sphinx", "3.2.1", "BSD"}:                     {BSD2, BSD3, MIT},
-		{"chardet", "3.0.4", "LGPL"}:                   {LGPL21OrLater},
-		{"colorama", "0.4.3", "BSD"}:                   {BSD3},
-		{"colorama", "0.4.4", "BSD"}:                   {BSD3},
-		{"decorator", "4.4.2", "new BSD License"}:      {BSD2},
-		{"gitdb", "4.0.5", "BSD License"}:              {BSD3},
-		{"idna", "2.6", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
-		{"idna", "2.7", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
-		{"idna", "2.8", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
-		{"idna", "2.9", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
-		{"importlib-resources", "5.4.0", "UNKNOWN"}:    {Apache2},
-		{"itsdangerous", "1.1.0", "BSD"}:               {BSD3},
-		{"jsonpatch", "1.30", "Modified BSD License"}:  {BSD3},
-		{"jsonpatch", "1.32", "Modified BSD License"}:  {BSD3},
-		{"jsonpointer", "2.0", "Modified BSD License"}: {BSD3},
-		{"jsonpointer", "2.2", "Modified BSD License"}: {BSD3},
-		{"jsonschema", "3.2.0", "UNKNOWN"}:             {MIT},
-		{"lockfile", "0.12.2", "UNKNOWN"}:              {MIT},
-		{"oauthlib", "3.1.0", "BSD"}:                   {BSD3},
-		{"oauthlib", "3.2.0", "BSD"}:                   {BSD3},
-		{"pep517", "0.12.0", "UNKNOWN"}:                {MIT},
-		{"pep517", "0.8.2", "UNKNOWN"}:                 {MIT},
-		{"pip-tools", "5.3.1", "BSD"}:                  {BSD3},
-		{"ptyprocess", "0.6.0", "UNKNOWN"}:             {ISC},
-		{"pyasn1", "0.4.8", "BSD"}:                     {BSD2},
-		{"pycparser", "2.20", "BSD"}:                   {BSD3},
-		{"python-dateutil", "2.8.1", "Dual License"}:   {BSD3, Apache2},
-		{"python-dateutil", "2.8.2", "Dual License"}:   {BSD3, Apache2},
-		{"python-json-logger", "2.0.1", "BSD"}:         {BSD2},
-		{"python-json-logger", "2.0.2", "BSD"}:         {BSD2},
-		{"scout.py", "0.3.0", "UNKNOWN"}:               {AmbassadorProprietary},
-		{"rsa", "4.8", "Apache-2.0"}:                   {Apache2},
-		{"semantic-version", "2.6.0", "BSD"}:           {BSD2},
-		{"semantic-version", "2.8.5", "BSD"}:           {BSD2},
-		{"smmap", "3.0.4", "BSD"}:                      {BSD3},
-		{"tomli", "1.2.2", "UNKNOWN"}:                  {MIT},
-		{"webencodings", "0.5.1", "BSD"}:               {BSD3},
-		{"websocket-client", "0.57.0", "BSD"}:          {BSD3},
-		{"websocket-client", "1.2.3", "Apache-2.0"}:    {Apache2},
-		{"zipp", "3.6.0", "UNKNOWN"}:                   {MIT},
+var hardcodedPythonDependencies = map[tuple][]License{
+	// These are packages that don't have sufficient metadata to get
+	// the license normally.  Either the license isn't specified in
+	// the metadata, or the license string that is specified is
+	// ambiguous (for example: "BSD" is too ambiguous, which variant
+	// of the BSD license is it?).  We pin the exact versions so
+	// that a human has to go make sure that the license didn't
+	// change when upgrading.
+	{"Babel", "2.8.0", "BSD"}:                      {BSD3},
+	{"CacheControl", "0.12.6", "UNKNOWN"}:          {Apache2},
+	{"CacheControl", "0.12.10", "UNKNOWN"}:         {Apache2},
+	{"Click", "7.0", "BSD"}:                        {BSD3},
+	{"Flask", "1.0.2", "BSD"}:                      {BSD3},
+	{"GitPython", "3.1.8", "UNKNOWN"}:              {BSD3},
+	{"GitPython", "3.1.11", "UNKNOWN"}:             {BSD3},
+	{"Jinja2", "2.10.1", "BSD"}:                    {BSD3},
+	{"Pygments", "2.7.1", "BSD License"}:           {BSD2},
+	{"Sphinx", "3.2.1", "BSD"}:                     {BSD2, BSD3, MIT},
+	{"chardet", "3.0.4", "LGPL"}:                   {LGPL21OrLater},
+	{"colorama", "0.4.3", "BSD"}:                   {BSD3},
+	{"colorama", "0.4.4", "BSD"}:                   {BSD3},
+	{"decorator", "4.4.2", "new BSD License"}:      {BSD2},
+	{"gitdb", "4.0.5", "BSD License"}:              {BSD3},
+	{"idna", "2.6", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
+	{"idna", "2.7", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
+	{"idna", "2.8", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
+	{"idna", "2.9", "BSD-like"}:                    {BSD3, PSF, Unicode2015},
+	{"importlib-resources", "5.4.0", "UNKNOWN"}:    {Apache2},
+	{"itsdangerous", "1.1.0", "BSD"}:               {BSD3},
+	{"jsonpatch", "1.30", "Modified BSD License"}:  {BSD3},
+	{"jsonpatch", "1.32", "Modified BSD License"}:  {BSD3},
+	{"jsonpointer", "2.0", "Modified BSD License"}: {BSD3},
+	{"jsonpointer", "2.2", "Modified BSD License"}: {BSD3},
+	{"jsonschema", "3.2.0", "UNKNOWN"}:             {MIT},
+	{"lockfile", "0.12.2", "UNKNOWN"}:              {MIT},
+	{"oauthlib", "3.1.0", "BSD"}:                   {BSD3},
+	{"oauthlib", "3.2.0", "BSD"}:                   {BSD3},
+	{"pep517", "0.12.0", "UNKNOWN"}:                {MIT},
+	{"pep517", "0.8.2", "UNKNOWN"}:                 {MIT},
+	{"pip-tools", "5.3.1", "BSD"}:                  {BSD3},
+	{"ptyprocess", "0.6.0", "UNKNOWN"}:             {ISC},
+	{"pyasn1", "0.4.8", "BSD"}:                     {BSD2},
+	{"pycparser", "2.20", "BSD"}:                   {BSD3},
+	{"python-dateutil", "2.8.1", "Dual License"}:   {BSD3, Apache2},
+	{"python-dateutil", "2.8.2", "Dual License"}:   {BSD3, Apache2},
+	{"python-json-logger", "2.0.1", "BSD"}:         {BSD2},
+	{"python-json-logger", "2.0.2", "BSD"}:         {BSD2},
+	{"scout.py", "0.3.0", "UNKNOWN"}:               {AmbassadorProprietary},
+	{"rsa", "4.8", "Apache-2.0"}:                   {Apache2},
+	{"semantic-version", "2.6.0", "BSD"}:           {BSD2},
+	{"semantic-version", "2.8.5", "BSD"}:           {BSD2},
+	{"smmap", "3.0.4", "BSD"}:                      {BSD3},
+	{"tomli", "1.2.2", "UNKNOWN"}:                  {MIT},
+	{"webencodings", "0.5.1", "BSD"}:               {BSD3},
+	{"websocket-client", "0.57.0", "BSD"}:          {BSD3},
+	{"websocket-client", "1.2.3", "Apache-2.0"}:    {Apache2},
+	{"zipp", "3.6.0", "UNKNOWN"}:                   {MIT},
 
-		// These are packages with non-trivial strings to parse, and
-		// it's easier to just hard-code it.
-		{"docutils", "0.15.2", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3OrLater},
-		{"docutils", "0.17.1", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3OrLater},
-		{"docutils", "0.18.1", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3OrLater},
-		{"orjson", "3.3.1", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
-		{"orjson", "3.6.0", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
-		{"orjson", "3.6.6", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
-		{"packaging", "20.4", "BSD-2-Clause or Apache-2.0"}:                                    {BSD2, Apache2},
-		{"packaging", "20.9", "BSD-2-Clause or Apache-2.0"}:                                    {BSD2, Apache2},
-	}[tuple{name, version, license}]
+	// These are packages with non-trivial strings to parse, and
+	// it's easier to just hard-code it.
+	{"docutils", "0.15.2", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3OrLater},
+	{"docutils", "0.17.1", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3OrLater},
+	{"docutils", "0.18.1", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3OrLater},
+	{"orjson", "3.3.1", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
+	{"orjson", "3.6.0", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
+	{"orjson", "3.6.6", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
+	{"packaging", "20.4", "BSD-2-Clause or Apache-2.0"}:                                    {BSD2, Apache2},
+	{"packaging", "20.9", "BSD-2-Clause or Apache-2.0"}:                                    {BSD2, Apache2},
+}
+
+func parseLicenses(name, version, license string) map[License]struct{} {
+	override, ok := hardcodedPythonDependencies[tuple{name, version, license}]
 	if ok {
 		ret := make(map[License]struct{}, len(override))
 		for _, l := range override {

--- a/cmd/py-mkopensource/main_test.go
+++ b/cmd/py-mkopensource/main_test.go
@@ -138,14 +138,14 @@ func TestLicenseErrors(t *testing.T) {
 			"./testdata/agpl-license/dependency_list.txt",
 			markdownOutputType,
 			internalApplication,
-			"is forbidden",
+			"Dependency 'infomap@2.0.2' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden",
 		},
 		{
 			"AGPL licenses are forbidden for internal use - JSON format",
 			"./testdata/agpl-license/dependency_list.txt",
 			jsonOutputType,
 			internalApplication,
-			"is forbidden",
+			"Dependency 'infomap@2.0.2' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden",
 		},
 		{
 			"AGPL licenses are forbidden for external use - Markdown format",

--- a/cmd/py-mkopensource/main_test.go
+++ b/cmd/py-mkopensource/main_test.go
@@ -111,7 +111,7 @@ func TestJsonOutput(t *testing.T) {
 	}
 }
 
-func TestForbiddenLicenses(t *testing.T) {
+func TestLicenseErrors(t *testing.T) {
 	testCases := []struct {
 		testName             string
 		dependencies         string
@@ -160,6 +160,13 @@ func TestForbiddenLicenses(t *testing.T) {
 			jsonOutputType,
 			externalApplication,
 			"is forbidden",
+		},
+		{
+			"Unknown licenses are identified correctly",
+			"./testdata/unknown-license/dependency_list.txt",
+			jsonOutputType,
+			externalApplication,
+			"Python package \"CacheControl\" \"1.99.6\": Could not parse license-string \"UNKNOWN\"",
 		},
 	}
 

--- a/cmd/py-mkopensource/main_test.go
+++ b/cmd/py-mkopensource/main_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"io"
 	"os"
+	"path"
 	"testing"
 )
 
@@ -56,7 +57,7 @@ func TestMarkdownOutput(t *testing.T) {
 			require.NoError(t, readErr)
 
 			expectedOutput := getFileContents(t, testCase.expectedOutput)
-			require.Equal(t, string(expectedOutput), string(programOutput))
+			require.Equal(t, expectedOutput, string(programOutput))
 		})
 	}
 }
@@ -121,59 +122,59 @@ func TestLicenseErrors(t *testing.T) {
 	}{
 		{
 			"GPL licenses are forbidden for external use - Markdown format",
-			"./testdata/gpl-license/dependency_list.txt",
+			"./testdata/gpl-license",
 			markdownOutputType,
 			externalApplication,
 			"Dependency 'docutils@0.17.1' uses license 'GNU General Public License v3.0 or later' which is not allowed on applications that run on customer machines.",
 		},
 		{
 			"GPL licenses are forbidden for external use - JSON format",
-			"./testdata/gpl-license/dependency_list.txt",
+			"./testdata/gpl-license",
 			jsonOutputType,
 			externalApplication,
 			"Dependency 'docutils@0.17.1' uses license 'GNU General Public License v3.0 or later' which is not allowed on applications that run on customer machines.",
 		},
 		{
 			"AGPL licenses are forbidden for internal use - Markdown format",
-			"./testdata/agpl-license/dependency_list.txt",
+			"./testdata/agpl-license",
 			markdownOutputType,
 			internalApplication,
 			"Dependency 'infomap@2.0.2' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden",
 		},
 		{
 			"AGPL licenses are forbidden for internal use - JSON format",
-			"./testdata/agpl-license/dependency_list.txt",
+			"./testdata/agpl-license",
 			jsonOutputType,
 			internalApplication,
 			"Dependency 'infomap@2.0.2' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden",
 		},
 		{
 			"AGPL licenses are forbidden for external use - Markdown format",
-			"./testdata/agpl-license/dependency_list.txt",
+			"./testdata/agpl-license",
 			markdownOutputType,
 			externalApplication,
 			"is forbidden",
 		},
 		{
 			"AGPL licenses are forbidden for external use - JSON format",
-			"./testdata/agpl-license/dependency_list.txt",
+			"./testdata/agpl-license",
 			jsonOutputType,
 			externalApplication,
 			"is forbidden",
 		},
 		{
 			"Unknown licenses are identified correctly",
-			"./testdata/unknown-license/dependency_list.txt",
+			"./testdata/unknown-license",
 			jsonOutputType,
 			externalApplication,
-			"Python package \"CacheControl\" \"1.99.6\": Could not parse license-string \"UNKNOWN\"",
+			"Package\"CacheControl\" \"1.99.6\": Could not parse license-string \"UNKNOWN\"",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
 			//Arrange
-			pipDependencies, err := os.Open(testCase.dependencies)
+			pipDependencies, err := os.Open(path.Join(testCase.dependencies, "dependency_list.txt"))
 			require.NoError(t, err)
 			defer func() { _ = pipDependencies.Close() }()
 
@@ -183,18 +184,19 @@ func TestLicenseErrors(t *testing.T) {
 			// Act
 			err = Main(markdownOutputType, testCase.applicationType, pipDependencies, w)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), testCase.expectedErrorMessage)
+			expectedError := getFileContents(t, path.Join(testCase.dependencies, "expected_err.txt"))
+			require.Equal(t, expectedError, err.Error())
 			_ = w.Close()
 		})
 	}
 }
 
-func getFileContents(t *testing.T, path string) []byte {
+func getFileContents(t *testing.T, path string) string {
 	content, err := os.ReadFile(path)
 	if err != nil && err != io.EOF {
 		require.NoError(t, err)
 	}
-	return content
+	return string(content)
 }
 
 func getDependencyInfoFromFile(t *testing.T, path string) *dependencies.DependencyInfo {

--- a/cmd/py-mkopensource/testdata/agpl-license/expected_err.txt
+++ b/cmd/py-mkopensource/testdata/agpl-license/expected_err.txt
@@ -1,0 +1,8 @@
+1 license-forbidden error:
+ 1. Dependency 'infomap@2.0.2' uses license 'GNU Affero General Public License v3.0 or later' which is forbidden.
+    To solve this error, replace the dependency with another that uses
+    an acceptable license.
+
+    Refer to
+    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
+    for more details.

--- a/cmd/py-mkopensource/testdata/gpl-license/expected_err.txt
+++ b/cmd/py-mkopensource/testdata/gpl-license/expected_err.txt
@@ -1,0 +1,8 @@
+1 intended-usage error:
+ 1. Dependency 'docutils@0.17.1' uses license 'GNU General Public License v3.0 or later' which is not allowed on applications that run on customer machines.
+    To solve this error, replace the dependency with another that uses
+    an acceptable license.
+
+    Refer to
+    https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157#1cd50aeeafa7456bba24c761c0a2d173
+    for more details.

--- a/cmd/py-mkopensource/testdata/unknown-license/dependency_list.txt
+++ b/cmd/py-mkopensource/testdata/unknown-license/dependency_list.txt
@@ -1,0 +1,11 @@
+Name: CacheControl
+Version: 1.99.6
+Summary: httplib2 caching for requests
+Home-page: https://github.com/ionrock/cachecontrol
+Author: Eric Larson
+Author-email: eric@ionrock.org
+License: UNKNOWN
+Location: /usr/lib/python3.8/site-packages
+Requires: requests, msgpack
+Required-by:
+

--- a/cmd/py-mkopensource/testdata/unknown-license/expected_err.txt
+++ b/cmd/py-mkopensource/testdata/unknown-license/expected_err.txt
@@ -1,0 +1,17 @@
+1 license-detection error:
+ 1. distrib "CacheControl" "1.99.6": Could not parse license-string "UNKNOWN"
+    This probably means that you added or upgraded a dependency, and the
+    automated opensource-license-checker can't confidently detect what
+    the license is.  (This is a good thing, because it is reminding you
+    to check the license of libraries before using them.)
+
+    Some possible causes for this issue are:
+
+    - Dependency is proprietary Ambassador Labs software: Update
+    function IsAmbassadorProprietarySoftware() to correctly identify the
+    dependency
+
+    - License information can't be identified: Add an entry to
+    hardcodedGoDependencies, hardcodedPythonDependencies or
+    hardcodedJsDependencies depending on the dependency that was not
+    identified.

--- a/pkg/dependencies/dependencyinfo.go
+++ b/pkg/dependencies/dependencyinfo.go
@@ -104,25 +104,6 @@ func getLicenseFromName(licenseName string) (License, error) {
 	return license, nil
 }
 
-// CheckLicenses checks that the licenses used by the dependencies are known and allowed to be used
-//in an application based on the buiness logic described here: https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157.
-//This function must be called after parsing of the licenses has been done.
-func (d *DependencyInfo) CheckLicenses(licenseRestriction LicenseRestriction) error {
-	if licenseRestriction == Forbidden {
-		return fmt.Errorf("forbidden licenses should not be used")
-	}
-
-	for _, dependency := range d.Dependencies {
-		for _, licenseName := range dependency.Licenses {
-			err := CheckLicenseRestrictions(dependency, licenseName, licenseRestriction)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func CheckLicenseRestrictions(dependency Dependency, licenseName string, licenseRestriction LicenseRestriction) error {
 	license, err := getLicenseFromName(licenseName)
 	if err != nil {


### PR DESCRIPTION
Python scanner was not using the same logic as Go scanner when an error was found, which made it difficult to figure out what was happening.

This PR makes bot CLI tools consistent, so all Python errors are identified and printed, instead of printing one error at a time.