### PR TITLE
Support NPM depencency json to have licenses as string or as list

### DIFF
--- a/cmd/js-mkopensource/dependency/dependency_test.go
+++ b/cmd/js-mkopensource/dependency/dependency_test.go
@@ -37,6 +37,10 @@ func TestSuccessfulGeneration(t *testing.T) {
 			"GPL license is allowed in internal software",
 			"./testdata/dependency-with-gpl-license",
 		},
+		{
+			"License field can be string or array",
+			"./testdata/license-field-as-an-array",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -72,6 +76,10 @@ func TestErrorScenarios(t *testing.T) {
 		{
 			"Missing license",
 			"./testdata/missing-license",
+		},
+		{
+			"Empty license field",
+			"./testdata/empty-license",
 		},
 		{
 			"Hardcode dependency with different version is rejected",

--- a/cmd/js-mkopensource/dependency/hardcodeddependencies.go
+++ b/cmd/js-mkopensource/dependency/hardcodeddependencies.go
@@ -10,6 +10,7 @@ var hardcodedJsDependencies = map[string][]string{
 	"flexboxgrid@6.3.1":            {Apache2.Name},
 	"indexof@0.0.1":                {MIT.Name},
 	"intro.js@4.1.0":               {AGPL3OrLater.Name},
+	"json-schema@0.2.3":            {AFL21.Name},
 	"node-forge@0.10.0":            {BSD3.Name},
 	"pako@1.0.10":                  {MIT.Name},
 	"regenerator-transform@0.10.1": {BSD2.Name},

--- a/cmd/js-mkopensource/dependency/testdata/empty-license/dependencies.json
+++ b/cmd/js-mkopensource/dependency/testdata/empty-license/dependencies.json
@@ -1,0 +1,14 @@
+{
+  "agent-base@6.0.2": {
+    "name": "agent-base",
+    "version": "6.0.2",
+    "licenses": "",
+    "repository": "https://github.com/TooTallNate/node-agent-base",
+    "publisher": "Nathan Rajlich",
+    "email": "nathan@tootallnate.net",
+    "url": "http://n8.io/",
+    "dependencyPath": "/app/node_modules/agent-base",
+    "path": "/app/node_modules/agent-base",
+    "licenseFile": "/app/node_modules/agent-base/README.md"
+  }
+}

--- a/cmd/js-mkopensource/dependency/testdata/empty-license/expected_err.txt
+++ b/cmd/js-mkopensource/dependency/testdata/empty-license/expected_err.txt
@@ -1,5 +1,5 @@
 1 license-detection error:
- 1. Dependency 'agent-base@6.0.2' has an invalid license field: <nil>
+ 1. Dependency 'agent-base@6.0.2' is missing a license identifier.
     This probably means that you added or upgraded a dependency, and the
     automated opensource-license-checker can't confidently detect what
     the license is.  (This is a good thing, because it is reminding you

--- a/cmd/js-mkopensource/dependency/testdata/license-field-as-an-array/dependencies.json
+++ b/cmd/js-mkopensource/dependency/testdata/license-field-as-an-array/dependencies.json
@@ -1,0 +1,19 @@
+{
+  "json-schema@0.2.3": {
+    "licenses": [
+      "AFLv2.1",
+      "CC-BY-3.0"
+    ],
+    "repository": "https://github.com/kriszyp/json-schema",
+    "publisher": "Kris Zyp",
+    "name": "json-schema",
+    "version": "0.2.3",
+    "description": "JSON Schema validation and specifications",
+    "licenseFile": "/app/ui/node_modules/json-schema/README.md",
+    "licenseText": "JSON Schema is a repository for the JSON Schema specification, reference schemas and a CommonJS implementation of JSON Schema (not the only JavaScript implementation of JSON Schema, JSV is another excellent JavaScript validator).\r\n\r\nCode is licensed under the AFL or BSD license as part of the Persevere \r\nproject which is administered under the Dojo foundation,\r\nand all contributions require a Dojo CLA.",
+    "licenseModified": "",
+    "url": "",
+    "path": "/app/ui/node_modules/json-schema"
+  }
+}
+

--- a/cmd/js-mkopensource/dependency/testdata/license-field-as-an-array/expected_output.json
+++ b/cmd/js-mkopensource/dependency/testdata/license-field-as-an-array/expected_output.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": [
+    {
+      "name": "json-schema",
+      "version": "0.2.3",
+      "licenses": [
+        "Academic Free License v2.1",
+        "Creative Commons Attribution 3.0 Unported"
+      ]
+    }
+  ],
+  "licenseInfo": {
+    "Academic Free License v2.1": "https://spdx.org/licenses/AFL-2.1.html",
+    "Creative Commons Attribution 3.0 Unported": "https://spdx.org/licenses/CC-BY-3.0.html"
+  }
+}

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -112,6 +112,7 @@ var (
 		"0BSD":              ZeroBSD,
 		"Apache-2.0":        Apache2,
 		"AFL-2.1":           AFL21,
+		"AFLv2.1":           AFL21,
 		"AGPL-1.0-only":     AGPL1Only,
 		"AGPL-1.0-or-later": AGPL1OrLater,
 		"AGPL-3.0-only":     AGPL3Only,


### PR DESCRIPTION
License scanner for NPM sometimes outputs licenses as a string and sometimes as a list

String sample
```
"licenses": "MIT"
```

List sample
```
"licenses": [
      "AFLv2.1",
      "CC-BY-3.0"
    ]
```

List format was not supported and this PR adds support for it.

In addition, NPM library `json-schema@0.2.3` has a license that's difficult to parse and it was hard-coded.