### PR TITLE
Include platform-specific dependencies in DEPENDENCIES.md file for Node.Js

### DIFF
--- a/build-aux/docker/scan-js.sh
+++ b/build-aux/docker/scan-js.sh
@@ -18,7 +18,7 @@ scan_npm_package() {
   fi
 
   echo >&2 "Analyzing package ${PKG_NAME}"
-  npm >&2 install
+  npm install -f >&2
 
   PACKAGE_DEPS="/temp/${PKG_NAME}-licenses.json"
   license-checker --excludePackages "${PKG_NAME}" --customPath "/scripts/customLicenseFormat.json" \


### PR DESCRIPTION
**What**
Install npm dependencies using the `-f` (Force) option, so that platform-specific dependencies are installed.

**Why**
GitHub checks are failing for some people in the Cloud team because they use macOs and GitHub check runs on Linux.
Due to this, check will fail indicating that file `DEPENDENCIES.md` is out-of-date.

See [this](https://github.com/datawire/saas_app/runs/5294070577?check_suite_focus=true) failure for an example of this issue.

**Tests**
Ran Node.Js dependency script on a Linux machine and verified that macOs, Windows, etc. dependencies are included in `DEPENDENCIES.md` file

**Risks**
It seems like `npm install` will just download all dependencies. It doesn't try to compile or run any code, so installation works on any system. For example, fsevents is a macOs only package, and I was able to 'install' it on a linux machine.

However. if there was platform-specific code that would have to run during installation, dependency generation would fail.
