### PR TITLE
Add an escape-hatch yaml file that maps packages to SPDX licenses

### DIFF
--- a/pkg/detectlicense/package_licenses_file.go
+++ b/pkg/detectlicense/package_licenses_file.go
@@ -1,0 +1,36 @@
+package detectlicense
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReadPackageLicensesFromFile reads package licenses from a file.
+func ReadPackageLicensesFromFile(name string) (map[string]map[License]struct{}, error) {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		}
+		return nil, err
+	}
+	var pns map[string][]string
+	if err = yaml.Unmarshal(data, &pns); err != nil {
+		return nil, err
+	}
+	plm := make(map[string]map[License]struct{}, len(pns))
+	for pkg, ids := range pns {
+		lm := make(map[License]struct{}, len(ids))
+		for _, id := range ids {
+			l, ok := SpdxIdentifiers[id]
+			if !ok {
+				return nil, fmt.Errorf("%q is not a valid SPDX License identifier. See https://spdx.org/licenses/ for a full litst", id)
+			}
+			lm[l] = struct{}{}
+		}
+		plm[pkg] = lm
+	}
+	return plm, nil
+}

--- a/pkg/detectlicense/package_licenses_file_test.go
+++ b/pkg/detectlicense/package_licenses_file_test.go
@@ -1,0 +1,50 @@
+package detectlicense
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestReadPackageLicensesFromFile(t *testing.T) {
+	tmp := t.TempDir()
+	pls := map[string][]string{
+		"github.com/alpha/one": {"Apache-2.0"},
+		"github.com/beta/two":  {"MIT", "LGPL-3.0-only"},
+	}
+	fn := filepath.Join(tmp, "unparsable-packages.yaml")
+	f, err := os.Create(fn)
+	require.NoError(t, err)
+	require.NoError(t, yaml.NewEncoder(f).Encode(pls))
+	require.NoError(t, f.Close())
+
+	plm, err := ReadPackageLicensesFromFile(fn)
+	require.NoError(t, err)
+	require.Equal(t, map[string]map[License]struct{}{
+		"github.com/alpha/one": {
+			Apache2: {},
+		},
+		"github.com/beta/two": {
+			MIT:       {},
+			LGPL3Only: {},
+		},
+	}, plm)
+}
+
+func TestReadPackageLicensesFromFile_invalidName(t *testing.T) {
+	tmp := t.TempDir()
+	pls := map[string][]string{
+		"github.com/alpha/one": {"invalid-spdx-id"},
+	}
+	fn := filepath.Join(tmp, "unparsable-packages.yaml")
+	f, err := os.Create(fn)
+	require.NoError(t, err)
+	require.NoError(t, yaml.NewEncoder(f).Encode(pls))
+	require.NoError(t, f.Close())
+
+	_, err = ReadPackageLicensesFromFile(fn)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Some components cannot be parsed by this license checker and this
creates a churn when upgrading component versions, making such upgrades
dependent on new versions of this checker. Typical scenario

1. We want to release a new version of component x.
2. The new release must use the latest of component y.
3. The go-mkopensource refuses to parse something that the y points to.
4. Our release is blocked on a new mk-opensource release.

This addition removes the block by making it possible for component x
to specify the SPDX licenses that component y is using.

Closes #8 