### PR TITLE
Enable npm packages exclusions

### DIFF
--- a/build-aux/docker/js_builder.dockerfile
+++ b/build-aux/docker/js_builder.dockerfile
@@ -19,6 +19,7 @@ FROM ${NODE_IMAGE} as npm_dependency_scanner
 
 ARG APPLICATION_TYPE
 ENV APPLICATION_TYPE="${APPLICATION_TYPE}"
+ENV EXCLUDED_PKG="${EXCLUDED_PKG}"
 
 RUN apk --no-cache add \
     bash \

--- a/build-aux/docker/scan-js.sh
+++ b/build-aux/docker/scan-js.sh
@@ -20,8 +20,10 @@ scan_npm_package() {
   echo >&2 "Analyzing package ${PKG_NAME}"
   npm install -f >&2
 
+  echo >&2 "Packages excluded: "${EXCLUDED_PKG}""
+
   PACKAGE_DEPS="/temp/${PKG_NAME}-licenses.json"
-  license-checker --excludePackages "${PKG_NAME}" --customPath "/scripts/customLicenseFormat.json" \
+  license-checker --excludePackages "${PKG_NAME};${EXCLUDED_PKG}" --customPath "/scripts/customLicenseFormat.json" \
     --json >"${PACKAGE_DEPS}"
 
   /scripts/js-mkopensource --application-type=${APPLICATION_TYPE} < <(cat "${PACKAGE_DEPS}") >"$2"

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -80,6 +80,7 @@ if [ -n "${NPM_PACKAGES}" ]; then
 
   docker run --rm \
     --env APPLICATION \
+    --env EXCLUDED_PKG="${EXCLUDED_PKG}" \
     --env USER_ID=${UID} \
     --volume "$(realpath ${BUILD_TMP})":/temp \
     js-deps-builder /scripts/scan-js.sh


### PR DESCRIPTION
### What?

Add the `EXCLUDED_PKG` env variable

### Why?

In saas_app we have an issue with intro.js package, we already paid for the commercial license but it is still an AGPL license, to handle this case we need to be able to let the scrip know in which packages we don't want to run the validation.