### PR TITLE
install dependencies with the scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ sigs.k8s.io/json/internal/golang/encoding/json:
 
 We then use the flag `--unparsable-packages unparsable-packages.yaml` when running `go-mkopensource`.
 
+Example:
+In previous versions of this scanner, sometimes the scanner complains about missing dependencies when the scanner gets
+the list of all the packages in the file "vendor/modules.txt" using the command "go mod vendor" You can see that in the following output.
+```bash
+#26 18.21 go: downloading github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916
+#26 18.24 go: downloading github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+#26 18.28 go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+#26 36.85 github.com/datawire/saas_app/internal/pkg/kubernetes imports
+#26 36.85 	k8s.io/client-go/rest imports
+#26 36.85 	k8s.io/apimachinery/pkg/util/clock: no required module provides package k8s.io/apimachinery/pkg/util/clock; to add it:
+#26 36.85 	go get k8s.io/apimachinery/pkg/util/clock
+#26 36.85 /scripts/go-mkopensource: fatal: ["go" "mod" "vendor"]: exit status 1
+#26 ERROR: executor failed running [/bin/sh -c /scripts/scan-go.sh]: exit code: 1
+```
+Now the scanner is smart enough to follow the indications of the "go mod vendor"  install the dependencies, and then 
+get the list of packages from the file ''vendor/modules.txt"
+
+Sometimes it isn't possible to install the dependecies sugested by the "go mod vendor" command. 
+The scanner will complain with the message "Error installing dependency". In this case the project will require human intervention to solve the problem.
+
 ### Remember to always create a ticket!
 When a problem arise, remember to always create a ticket so that the problem can be fixed. This will help all users
 of the `go-mkopensource` tool and in many cases also make the owner of the failing component aware of the problem.

--- a/cmd/go-mkopensource/modules_txt.go
+++ b/cmd/go-mkopensource/modules_txt.go
@@ -105,18 +105,15 @@ func VendorList() ([]golist.Package, error) {
 }
 
 func findAndGetDependencies(outputFromModVendor string) error {
-	log.Println(outputFromModVendor)
 	lines := strings.Split(outputFromModVendor, "\n")
 	var dependenciesToInstall []string
 	for _, line := range lines {
-		log.Println(line)
 		if strings.Contains(line, "go get") {
 			dependenciesToInstall = append(dependenciesToInstall, line)
 		}
 	}
 	for _, dependency := range dependenciesToInstall {
 		command := strings.Split(strings.TrimSpace(dependency), " ")
-		log.Printf("INSTALLING %s", strings.Join(command, ","))
 		cmd := exec.Command(command[0], command[1:]...)
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {

--- a/cmd/go-mkopensource/modules_txt.go
+++ b/cmd/go-mkopensource/modules_txt.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -23,8 +24,11 @@ func VendorList() ([]golist.Package, error) {
 	// - `cmd/go/internal/modcmd/vendor.go` for the code that writes modules.txt, and
 	// - `cmd/go/internal/modload/vendor.go` for the code that parses it.
 	cmd := exec.Command("go", "mod", "vendor")
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if out, err := cmd.CombinedOutput(); err != nil {
+		errInstall := findAndGetDependencies(string(out))
+		if errInstall == nil {
+			return VendorList()
+		}
 		return nil, fmt.Errorf("%q: %w", []string{"go", "mod", "vendor"}, err)
 	}
 
@@ -98,4 +102,27 @@ func VendorList() ([]golist.Package, error) {
 	}
 
 	return pkgs, nil
+}
+
+func findAndGetDependencies(outputFromModVendor string) error {
+	log.Println(outputFromModVendor)
+	lines := strings.Split(outputFromModVendor, "\n")
+	var dependenciesToInstall []string
+	for _, line := range lines {
+		log.Println(line)
+		if strings.Contains(line, "go get") {
+			dependenciesToInstall = append(dependenciesToInstall, line)
+		}
+	}
+	for _, dependency := range dependenciesToInstall {
+		command := strings.Split(strings.TrimSpace(dependency), " ")
+		log.Printf("INSTALLING %s", strings.Join(command, ","))
+		cmd := exec.Command(command[0], command[1:]...)
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Printf("Error installing dependency %v", err)
+			return fmt.Errorf("%q: %w", []string{"go", "mod", "vendor"}, err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Prior to this PR, the scanner didn't install the dependencies required by the `go mod vendor` command. With this PR, the scanner can install the dependencies and continue the scanning in the project. 

In order to test this PR, I use the master branch from saas_app on my local machine and update the [Makefile](https://github.com/datawire/saas_app/blob/33c1786904a5c0100d538d6d85ef632c47a1851a/Makefile#L754) to point to the latest commit in this PR. 