### PR TITLE
Pass the unparsable argument from the generate script to the scan-go

### DIFF
--- a/build-aux/docker/go_builder.dockerfile
+++ b/build-aux/docker/go_builder.dockerfile
@@ -17,6 +17,7 @@ RUN cp scan-go.sh imports.sh /out/
 
 FROM ${GO_IMAGE} as go_dependency_scanner
 
+ARG UNPARSABLE_PACKAGE
 ARG APPLICATION_TYPE
 ENV APPLICATION_TYPE="${APPLICATION_TYPE}"
 
@@ -43,7 +44,7 @@ ARG GIT_TOKEN
 RUN git config --global url."https://$GIT_TOKEN:@github.com/".insteadOf "https://github.com/"
 
 WORKDIR /app
-RUN /scripts/scan-go.sh
+RUN if [[ -z "$UNPARSABLE_PACKAGE" ]] ; then /scripts/scan-go.sh; else /scripts/scan-go.sh --unparsable-packages $UNPARSABLE_PACKAGE ; fi
 
 FROM scratch as license_output
 COPY --from=go_dependency_scanner /temp/* /

--- a/build-aux/docker/scan-go.sh
+++ b/build-aux/docker/scan-go.sh
@@ -11,10 +11,11 @@ cd /app
 
 GO_VERSION=$(go version | sed -E 's/.*go([1-9\.]*).*/\1/')
 
-/scripts/go-mkopensource --output-format=txt --package=mod --output-type=markdown --gotar="$(ls /data/go*.src.tar.gz)" >"${GO_DEPENDENCIES}"
+/scripts/go-mkopensource --output-format=txt --package=mod --output-type=markdown --gotar="$(ls /data/go*.src.tar.gz)" \
+  --unparsable-packages="$UNPARSABLE_PACKAGE_VALUE" >"${GO_DEPENDENCIES}"
 
 DEPENDENCY_INFO="${BUILD_TMP}/go_dependencies.json"
 /scripts/go-mkopensource --output-format=txt --package=mod --output-type=json --application-type=${APPLICATION_TYPE} \
-  --gotar="$(ls /data/go*.src.tar.gz)" >"${DEPENDENCY_INFO}"
+  --unparsable-packages="$UNPARSABLE_PACKAGE_VALUE" --gotar="$(ls /data/go*.src.tar.gz)" >"${DEPENDENCY_INFO}"
 
 jq -r '.licenseInfo | to_entries | .[] | "* [" + .key + "](" + .value + ")"' "${DEPENDENCY_INFO}" >"${GO_LICENSES}"

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -8,6 +8,16 @@ archive_dependencies() {
   tar -vf "$1" -c $2
 }
 
+UNPARSABLE_PACKAGE_VALUE=""
+
+if [ $# -gt 0 ]; then
+  if [ "$1" = "--unparsable-packages" ]; then
+    UNPARSABLE_PACKAGE_VALUE="$2"
+
+  fi
+fi
+
+
 BUILD_SCRIPTS=$(dirname $(realpath "$0"))
 . "${BUILD_SCRIPTS}/docker/imports.sh"
 
@@ -31,6 +41,7 @@ docker build \
   --build-arg GIT_TOKEN="${GIT_TOKEN}" \
   --build-arg GO_IMAGE="${GO_IMAGE}" \
   --build-arg SCRIPTS_HOME="${SCRIPTS_HOME}" \
+  --build-arg UNPARSABLE_PACKAGE="${UNPARSABLE_PACKAGE_VALUE}" \
   -t "go-deps-builder" --target license_output \
   --output "${BUILD_TMP}" .
 popd >/dev/null


### PR DESCRIPTION
Prior to this PR it wasn't possible to pass the argument `--unparsable-packages` from the `generate.sh` script to the scanner, then, some licenses are not validated properly. Now, we can pass the `--unparsable-packages` argument to the scanner thought the `generate.sh` script in order to add exceptions.

To testing this PR is possible to use the saas_app repo, checkout the [PR](https://github.com/datawire/saas_app/pull/4305) generated by dependabot. Then edit the Makefile to use the [commit](https://github.com/datawire/go-mkopensource/pull/42/commits/431b13fc6ab1e027f45ba28096dde6c10e0bf7d4) of this PR, and pass the `--unparsable-packages` as parameter to the `generate.sh` script like this:

```
MKOPENSOURCE_COMMIT = '431b13f'
$(LICENSE_TMP_DIR)/mkopensource:
	set -e; { \
	  unset GIT_DIR GIT_WORK_TREE; \
	  mkdir -p "$(CURDIR)/$@"; \
	  cd "$(CURDIR)/$@"; \
	  if test -e .git; then \
	    git fetch || true; \
	  else \
	    git clone https://github.com/datawire/go-mkopensource .; \
	  fi; \
	  git checkout $(MKOPENSOURCE_COMMIT); \
	}
.PHONY: $(LICENSE_TMP_DIR)/mkopensource

generate-dependency-info: $(LICENSE_TMP_DIR)/mkopensource $(NPM_PACKAGES)
	set -ex; { \
		if [ ! "$(TOKEN)" ]; then \
			printf '>>> $(bold)$(ccgreen)No GIT_TOKEN provided. Make sure you have hub installed and configured. See: https://github.com/github/hub$(sgr0)\n'; \
			exit 1; \
		fi; \
		\
		export APPLICATION="Ambassador Cloud"; \
		export APPLICATION_TYPE="internal"; \
		export BUILD_HOME='$(CURDIR)'; \
		export BUILD_TMP="$(LICENSE_TMP_DIR)/output"; \
		export SCRIPTS_HOME="$(LICENSE_TMP_DIR)/mkopensource"; \
		export GO_IMAGE=$$(grep -e 'FROM golang:' "$(CURDIR)/docker/base.Dockerfile" | cut -d ' ' -f2 ); \
		export NPM_PACKAGES="$(NPM_PACKAGES)"; \
		export EXCLUDED_PKG="$(EXCLUDED_PKG)"; \
		export NODE_IMAGE=$$(grep -e 'FROM node:' "$(CURDIR)/docker/system-a-ui.Dockerfile" | cut -d ' ' -f2 ); \
		export GIT_TOKEN="$(TOKEN)"; \
		"$(LICENSE_TMP_DIR)/mkopensource/build-aux/generate.sh" --unparsable-packages unparsable-packages.yaml; \
		sed -i'' -e '/@swc\/core-android/d; /@swc\/core-freebsd-/d; /@swc\/core-win32-/d; /@swc\/core-linux-arm/d; /@swc\/core-darwin-arm/d; ' DEPENDENCIES.md; \
	}

    # Manually added to include the dependency information, we need to automate this process
	echo "   intro.js                                                    5.0.0            AGPL3 Commercial" >> DEPENDENCIES.md
	echo "* Various commercial licenses" >> DEPENDENCY_LICENSES.md
.PHONY: generate-dependency-info
```
You should create the file `unparsable-packages.yaml` in the root path of the saas_app project with the following content:

```
sigs.k8s.io/json:
  - Apache-2.0
sigs.k8s.io/json/internal/golang/encoding/json:
  - BSD-3-Clause
```

To run the script you should export a Github personal token.
```
export GIT_TOKEN=<YOUR_PERSONAL_GITHUB_TOKEN>
```

Finally you can run the `generate.sh` script with the make command

```
 make generate-dependency-info
```