### PR TITLE
Return an error if there is none depency to install

### DIFF
--- a/cmd/go-mkopensource/modules_txt.go
+++ b/cmd/go-mkopensource/modules_txt.go
@@ -113,6 +113,7 @@ func findAndGetDependencies(outputFromModVendor string) error {
 		}
 	}
 	if len(dependenciesToInstall) <= 0 {
+		log.Println(outputFromModVendor)
 		return fmt.Errorf("none dependency required installation")
 	}
 	for _, dependency := range dependenciesToInstall {

--- a/cmd/go-mkopensource/modules_txt.go
+++ b/cmd/go-mkopensource/modules_txt.go
@@ -112,6 +112,9 @@ func findAndGetDependencies(outputFromModVendor string) error {
 			dependenciesToInstall = append(dependenciesToInstall, line)
 		}
 	}
+	if len(dependenciesToInstall) <= 0 {
+		return fmt.Errorf("none dependency required installation")
+	}
 	for _, dependency := range dependenciesToInstall {
 		command := strings.Split(strings.TrimSpace(dependency), " ")
 		cmd := exec.Command(command[0], command[1:]...)


### PR DESCRIPTION
Prior to this PR, if the go mod vendor command doesn't ask to install a dependency the scanner loops without finishing the process.

Now if the scanner doesn't find a dependency to install, it will fail in order to stop the process and ask for human intervention.

To test this PR checkout the master branch of saas_app, then go to the `go.sum` file in saas_app and delete any entry on it. Switch the `MKOPENSOURCE_COMMIT` in the `Makefile` for the commit on this PR. The scanner should fail. Also, the output from the `go mod vendor` command is displayed for a better understanding of the problem