### PR TITLE
Add an action to save updated dependency information if a workflow ran because of a dependabot change.

### DIFF
--- a/actions/save-dependabot-changes/action.yml
+++ b/actions/save-dependabot-changes/action.yml
@@ -1,0 +1,37 @@
+name: 'Save dependabot changes'
+description: "Check if dependencies were changed by dependabot and commit the new dependency information."
+inputs:
+  github_token:
+    description: |
+      Token used to commit changes back into the repository. 
+      This should be a personal access token, or commits made by this action won't trigger a new workflow run.
+      See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow for more info.
+    required: true
+
+outputs:
+  is_dirty:
+    description: "If there were changes made by dependabot, this variable will be true"
+    value: ${{ steps.check-dirty.outputs.DIRTY == 'true' }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check if dependencies changed
+      if: github.actor == 'dependabot[bot]' && github.ref_type == 'branch'
+      shell: bash
+      id: check-dirty
+      run: $GITHUB_ACTION_PATH/is_dirty.sh
+
+    - name: Update git credentials
+      if: steps.check-dirty.outputs.DIRTY == 'true'
+      shell: bash
+      run: |
+        set -o pipefail
+        AUTH=$(printf "%s""pat:${{ inputs.github_token }}" | base64)
+        echo "::add-mask::${AUTH}"
+        git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${AUTH}"
+
+    - name: Commit updated dependency files
+      if: steps.check-dirty.outputs.DIRTY == 'true'
+      shell: bash
+      run: $GITHUB_ACTION_PATH/commit.sh

--- a/actions/save-dependabot-changes/commit.sh
+++ b/actions/save-dependabot-changes/commit.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+git config --local user.name "d6eautomaton"
+git config --local user.email "<>"
+
+DESTINATION_BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+
+git checkout "${DESTINATION_BRANCH}"
+
+echo "Committing dependabot changes to DEPENDENCIES.md and/or DEPENDENCY_LICENSES.md"
+git commit -m  "Updated dependency information after dependabot change." DEPENDENCIES.md DEPENDENCY_LICENSES.md go.mod go.sum
+
+git push

--- a/actions/save-dependabot-changes/is_dirty.sh
+++ b/actions/save-dependabot-changes/is_dirty.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+if ! git diff --name-only --exit-code DEPENDENCIES.md; then
+    echo "DIRTY=true" >> $GITHUB_OUTPUT
+    exit 0
+fi
+
+if ! git diff --name-only --exit-code DEPENDENCY_LICENSES.md; then
+    echo "DIRTY=true" >> $GITHUB_OUTPUT
+    exit 0
+fi
+
+echo "There are no changes to save"
+echo "DIRTY=false" >> $GITHUB_OUTPUT

--- a/build-aux/docker/go_builder.dockerfile
+++ b/build-aux/docker/go_builder.dockerfile
@@ -2,7 +2,7 @@
 # Go dependency scanner
 ########################################
 ARG GO_IMAGE="base-image-unknown"
-FROM golang:1.17-alpine3.15 as builder
+FROM golang:1.19-alpine3.15 as builder
 
 WORKDIR /src
 COPY . ./

--- a/build-aux/docker/js_builder.dockerfile
+++ b/build-aux/docker/js_builder.dockerfile
@@ -2,7 +2,7 @@
 # builder for Js scanning
 ######################################################################
 ARG NODE_IMAGE="need-a-base-image"
-FROM golang:1.17-alpine3.15 as builder
+FROM golang:1.19-alpine3.15 as builder
 
 WORKDIR /src
 COPY . ./

--- a/build-aux/docker/py_builder.dockerfile
+++ b/build-aux/docker/py_builder.dockerfile
@@ -2,7 +2,7 @@
 # Python dependency scanner
 ########################################
 ARG PYTHON_IMAGE="need-a-base-image"
-FROM golang:1.17-alpine3.15 as builder
+FROM golang:1.19-alpine3.15 as builder
 
 WORKDIR /src
 COPY . ./

--- a/cmd/go-mkopensource/main.go
+++ b/cmd/go-mkopensource/main.go
@@ -299,7 +299,7 @@ func Main(args *CLIArgs) error {
 			}
 		} else {
 			if _, ok := unparsablePackages[pkgName]; ok {
-				licErrs = append(licErrs, fmt.Errorf(`Package %q has a valid license. It must removed from %s`,
+				licErrs = append(licErrs, fmt.Errorf(`Package %q has a valid license. It must be removed from %s`,
 					pkgName, args.UnparsablePackages))
 			}
 		}

--- a/cmd/go-mkopensource/modules_txt.go
+++ b/cmd/go-mkopensource/modules_txt.go
@@ -55,7 +55,8 @@ func (m *Modules) VendorList() ([]golist.Package, error) {
 
 		// Run go mod vendor again to update vendored dependencies
 		cmd = exec.Command("go", "mod", "vendor")
-		if err := cmd.Run(); err != nil {
+		if out, err = cmd.CombinedOutput(); err != nil {
+			log.Printf("'go mod vendor' failed:\n%s\n", out)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
# DESCRIPTION

This change adds an action that can be used in a workflow to detect when a dependabot change will make the dependency
information out of date, and will commit the updated dependency information, so the dependabot PR will not fail.

While testing the action I noticed failured due to the use of an old go docker image used during scanning so I fixed that.