### PR TITLE
Update action `save-dependabot-changes` to enable skipping changes made to some branches

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,70 @@
+name: "Smoke tests"
+on:
+  push:
+    paths:
+      - .github/workflows/test-action.yml
+permissions:
+  contents: write
+jobs:
+  generate_info:
+    name: "Generate dependency information"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: "Generate dependency information"
+        shell: bash
+        env:
+          APPLICATION: go-mkopensource
+          APPLICATION_TYPE: internal
+          BUILD_HOME: '.'
+          BUILD_TMP: '${{ runner.temp }}/license'
+          SCRIPTS_HOME: '.'
+          GIT_TOKEN: ${{ github.token }}
+        run: |
+          set -x
+          
+          export GO_IMAGE=$(grep -e 'FROM golang:' "build-aux/docker/go_builder.dockerfile" | cut -d ' ' -f2 )
+          mkdir -p "${BUILD_TMP}"
+          build-aux/generate.sh --output-format=txt --package=mod --output-type=markdown --gotar="go1.19.3.src.tar.gz" --unparsable-packages=./unparsable-packages.yaml
+
+          # Update dependency information to force action to run
+          echo -e "\n\nDependencies updated by '${GITHUB_WORKFLOW}' on $(date)" >> DEPENDENCY_LICENSES.md
+      
+
+      - name: "Verify if changes were made by dependabot"
+        id: changed-by-dependabot
+        uses: ./actions/save-dependabot-changes
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches_to_skip: master
+
+      - name: "Check that action didn't do any changes"
+        run: |
+          if [[ "${{ steps.changed-by-dependabot.outputs.is_dirty }}"  == 'true' ]]; then
+            exit 1
+          fi
+
+      - name: "Save dependency changes made by the last committer"
+        id: changed-by-dependabot2
+        uses: ./actions/save-dependabot-changes
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches_to_skip: master
+          actor: ${{ github.actor }}
+
+      - name: "Check that action pushed update back to the repository"
+        if:
+        run: |
+          if [[ "${{ steps.changed-by-dependabot2.outputs.is_dirty }}"  != 'true' ]]; then
+            exit 1
+          fi

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: "Verify if changes were made by dependabot"
         id: changed-by-dependabot
-        uses: ./actions/save-dependabot-changes
+        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branches_to_skip: master
@@ -56,7 +56,7 @@ jobs:
 
       - name: "Save dependency changes made by the last committer"
         id: changed-by-dependabot2
-        uses: ./actions/save-dependabot-changes
+        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branches_to_skip: master

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,15 @@
+The Go module "github.com/datawire/go-mkopensource" incorporates the
+following Free and Open Source software:
+
+    Name                                      Version                               License(s)
+    ----                                      -------                               ----------
+    the Go language standard library ("std")  v1.19.3                               3-clause BSD license
+    github.com/datawire/dlib                  v1.2.5-0.20211116212847-0316f8d7af2b  Apache License 2.0
+    github.com/davecgh/go-spew                v1.1.1                                ISC license
+    github.com/pkg/errors                     v0.9.1                                2-clause BSD license
+    github.com/pmezard/go-difflib             v1.0.0                                3-clause BSD license
+    github.com/spf13/pflag                    v1.0.5                                3-clause BSD license
+    github.com/stretchr/testify               v1.7.0                                MIT license
+    gopkg.in/yaml.v3                          v3.0.0-20200313102051-9f266ea9e77c    Apache License 2.0, MIT license
+
+

--- a/DEPENDENCY_LICENSES.md
+++ b/DEPENDENCY_LICENSES.md
@@ -1,0 +1,7 @@
+go-mkopensource incorporates Free and Open Source software under the following licenses:
+
+* [2-clause BSD license](https://opensource.org/licenses/BSD-2-Clause)
+* [3-clause BSD license](https://opensource.org/licenses/BSD-3-Clause)
+* [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
+* [ISC license](https://opensource.org/licenses/ISC)
+* [MIT license](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ jobs:
         uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.1
         with:
           github_token: ${{ secrets.PRIVATE_REPO_TOKEN }}
+          branches_to_skip: 'master'
       - name: Abort if dependencies changed
         if: steps.changed-by-dependabot.outputs.is_dirty == 'true'
         run: |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ When dependabot creates a PR, it's possible that license scanning will fail due 
 1. A Go package is unavailable in the new version of a module
 2. Dependency information is out of date.
 
-To reduce friction merging dependabot PRs, there is an action that will update a PR created by dependabot.
+To reduce friction merging dependabot PRs, there is an action (`save-dependabot-changes`) that will update a PR created by dependabot.
 
 Use the action in a workflow as follows:
 ```yaml
@@ -190,3 +190,15 @@ jobs:
 *Note*: Action's input `github_token` is a GitHub personal access token with at least `repo` permissions.
 Don't use the workflow's `GITHUB_TOKEN` token, or it won't run after changes are commited.
 See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow for more info.
+
+### Testing changes to the `save-dependabot-changes` action
+
+After the action has been updated, you can verify that it works as expected by updating the [smoke tests](.github/workflows/test-action.yml)
+to point to the new version of the action.
+
+```yaml
+uses: datawire/go-mkopensource/actions/save-dependabot-changes@<VERSION>
+```
+
+Note: If you want to test your changes before they are complete, you could use a branch in the action reference, and 
+update it to a tag once you're ready to release.  

--- a/actions/save-dependabot-changes/action.yml
+++ b/actions/save-dependabot-changes/action.yml
@@ -1,4 +1,4 @@
-name: 'Save dependabot changes'
+name: 'Update dependency information after dependabot updates'
 description: "Check if dependencies were changed by dependabot and commit the new dependency information."
 inputs:
   github_token:

--- a/actions/save-dependabot-changes/action.yml
+++ b/actions/save-dependabot-changes/action.yml
@@ -12,6 +12,13 @@ inputs:
     description: Regex of branches where this action should not run. e.g. 'master'
     required: true
 
+  actor:
+    description: |
+      The username of the user that triggered the initial workflow run. Used only for testing the action.
+      See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+    required: true
+    default: 'dependabot[bot]'
+
 outputs:
   is_dirty:
     description: "If there were changes made by dependabot, this variable will be true"
@@ -26,8 +33,8 @@ runs:
       run: |
         SOURCE_BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
 
-        if [[ "${GITHUB_ACTOR}" != 'dependabot[bot]' ]]; then
-          echo '::notice:: Action save-dependabot-changes is being skipped because actor is not dependabot'
+        if [[ "${GITHUB_ACTOR}" != '${{ inputs.actor }}' ]]; then
+          echo '::notice:: Action save-dependabot-changes is being skipped because actor is not ${{ inputs.actor }}'
           echo "SKIP=true" >> $GITHUB_OUTPUT
           exit
         fi        

--- a/actions/save-dependabot-changes/action.yml
+++ b/actions/save-dependabot-changes/action.yml
@@ -16,8 +16,26 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Check preconditions
+      id: preconditions
+      shell: bash
+      run: |
+        SOURCE_BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+
+        if [[ "${GITHUB_ACTOR}" != 'dependabot[bot]' ]]; then
+          echo '::notice:: Action save-dependabot-changes is being skipped because actor is not dependabot'
+          echo "SKIP=true" >> $GITHUB_OUTPUT
+          exit
+        fi        
+        
+        if [[ "${GITHUB_REF_TYPE}" != 'branch' ]]; then
+          echo '::notice:: Action save-dependabot-changes is being skipped because workflow is not running against a branch'
+          echo "SKIP=true" >> $GITHUB_OUTPUT
+          exit
+        fi        
+
     - name: Check if dependencies changed
-      if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && github.ref_type == 'branch'
+      if: steps.preconditions.outputs.SKIP != 'true'
       shell: bash
       id: check-dirty
       run: $GITHUB_ACTION_PATH/is_dirty.sh

--- a/actions/save-dependabot-changes/action.yml
+++ b/actions/save-dependabot-changes/action.yml
@@ -8,6 +8,10 @@ inputs:
       See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow for more info.
     required: true
 
+  branches_to_skip:
+    description: Regex of branches where this action should not run. e.g. 'master'
+    required: true
+
 outputs:
   is_dirty:
     description: "If there were changes made by dependabot, this variable will be true"
@@ -33,6 +37,17 @@ runs:
           echo "SKIP=true" >> $GITHUB_OUTPUT
           exit
         fi        
+
+        if [[ -z "${{ inputs.branches_to_skip }}" ]]; then
+          echo '::error:: Action save-dependabot-changes requires that parameter branches_to_skip have a non-empty value'
+          exit 1
+        fi
+
+        if grep --silent -E "${{ inputs.branches_to_skip }}" <(echo "${SOURCE_BRANCH}"); then
+          echo '::notice:: Action save-dependabot-changes is being skipped because branch matches the branches_to_skip regex'
+          echo "SKIP=true" >> $GITHUB_OUTPUT
+          exit
+        fi
 
     - name: Check if dependencies changed
       if: steps.preconditions.outputs.SKIP != 'true'

--- a/actions/save-dependabot-changes/commit.sh
+++ b/actions/save-dependabot-changes/commit.sh
@@ -8,7 +8,7 @@ DESTINATION_BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
 
 git checkout "${DESTINATION_BRANCH}"
 
-echo "Committing dependabot changes to DEPENDENCIES.md and/or DEPENDENCY_LICENSES.md"
+echo '::notice:: Committing dependabot changes to DEPENDENCIES.md and/or DEPENDENCY_LICENSES.md'
 git commit -m  "Updated dependency information after dependabot change." DEPENDENCIES.md DEPENDENCY_LICENSES.md go.mod go.sum
 
 git push

--- a/actions/save-dependabot-changes/is_dirty.sh
+++ b/actions/save-dependabot-changes/is_dirty.sh
@@ -2,14 +2,16 @@
 set -e
 
 if ! git diff --name-only --exit-code DEPENDENCIES.md; then
+    echo '::notice:: DEPENDENCIES.md and/or DEPENDENCY_LICENSES.md changed and they will be committed.'
     echo "DIRTY=true" >> $GITHUB_OUTPUT
     exit 0
 fi
 
 if ! git diff --name-only --exit-code DEPENDENCY_LICENSES.md; then
+    echo '::notice:: DEPENDENCIES.md and/or DEPENDENCY_LICENSES.md changed and they will be committed.'
     echo "DIRTY=true" >> $GITHUB_OUTPUT
     exit 0
 fi
 
-echo "There are no changes to save"
+echo "::debug:: There are no changes to save"
 echo "DIRTY=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Some workflows are calling action `save-dependabot-changes` on push, which could trigger an update of `master` after a merge.

This is not a problem if the user doing the merge is not dependabot, but since it's possible to enable auto-merge of dependabot PRs, this could be a problem.

This PR makes the following changes:
1. Add a new input argument `branches_to_skip` to the action
2. Improve logging, so it's easier to understand what's being done
3. Add tests to verify that the action behaves as expected.