### PR TITLE
Update action `save-dependabot-changes` to it does not need a privileged user to run

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,10 +1,12 @@
 name: "Smoke tests"
 on:
+  workflow_dispatch:
   push:
     paths:
       - .github/workflows/test-action.yml
 permissions:
   contents: write
+  actions: write
 jobs:
   generate_info:
     name: "Generate dependency information"
@@ -13,7 +15,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
@@ -40,12 +41,10 @@ jobs:
           # Update dependency information to force action to run
           echo -e "\n\nDependencies updated by '${GITHUB_WORKFLOW}' on $(date)" >> DEPENDENCY_LICENSES.md
       
-
       - name: "Verify if changes were made by dependabot"
         id: changed-by-dependabot
-        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.3
+        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           branches_to_skip: master
 
       - name: "Check that action didn't do any changes"
@@ -56,9 +55,8 @@ jobs:
 
       - name: "Save dependency changes made by the last committer"
         id: changed-by-dependabot2
-        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.3
+        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           branches_to_skip: master
           actor: ${{ github.actor }}
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -61,7 +61,7 @@ jobs:
           actor: ${{ github.actor }}
 
       - name: "Check that action pushed update back to the repository"
-        if:
+        if: github.ref_type == 'branch'
         run: |
           if [[ "${{ steps.changed-by-dependabot2.outputs.is_dirty }}"  != 'true' ]]; then
             exit 1

--- a/DEPENDENCY_LICENSES.md
+++ b/DEPENDENCY_LICENSES.md
@@ -5,3 +5,6 @@ go-mkopensource incorporates Free and Open Source software under the following l
 * [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
 * [ISC license](https://opensource.org/licenses/ISC)
 * [MIT license](https://opensource.org/licenses/MIT)
+
+
+Dependencies updated by 'Smoke tests' on Wed Feb  8 16:30:37 UTC 2023

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ jobs:
         id: changed-by-dependabot
         uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.1
         with:
-          github_token: ${{ secrets.PRIVATE_REPO_TOKEN }}
           branches_to_skip: 'master'
       - name: Abort if dependencies changed
         if: steps.changed-by-dependabot.outputs.is_dirty == 'true'
@@ -188,9 +187,11 @@ jobs:
       # Continue with other steps
 ```
 
-*Note*: Action's input `github_token` is a GitHub personal access token with at least `repo` permissions.
-Don't use the workflow's `GITHUB_TOKEN` token, or it won't run after changes are commited.
-See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow for more info.
+*Notes*:
+- The GitHub token GITHUB_TOKEN should have at least `contents:write` and `actions: write` 
+  [privileges](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).
+- The workflow that invokes the action should have a `workflow_dispatch` 
+  [trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).
 
 ### Testing changes to the `save-dependabot-changes` action
 

--- a/actions/save-dependabot-changes/action.yml
+++ b/actions/save-dependabot-changes/action.yml
@@ -1,13 +1,6 @@
 name: 'Update dependency information after dependabot updates'
 description: "Check if dependencies were changed by dependabot and commit the new dependency information."
 inputs:
-  github_token:
-    description: |
-      Token used to commit changes back into the repository. 
-      This should be a personal access token, or commits made by this action won't trigger a new workflow run.
-      See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow for more info.
-    required: true
-
   branches_to_skip:
     description: Regex of branches where this action should not run. e.g. 'master'
     required: true
@@ -62,16 +55,16 @@ runs:
       id: check-dirty
       run: $GITHUB_ACTION_PATH/is_dirty.sh
 
-    - name: Update git credentials
-      if: steps.check-dirty.outputs.DIRTY == 'true'
-      shell: bash
-      run: |
-        set -o pipefail
-        AUTH=$(printf "%s""pat:${{ inputs.github_token }}" | base64)
-        echo "::add-mask::${AUTH}"
-        git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${AUTH}"
-
     - name: Commit updated dependency files
       if: steps.check-dirty.outputs.DIRTY == 'true'
       shell: bash
       run: $GITHUB_ACTION_PATH/commit.sh
+
+    - name: Trigger workflow with the latest changes
+      if: steps.check-dirty.outputs.DIRTY == 'true' && github.actor == 'dependabot[bot]'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        DESTINATION_BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+        gh workflow run "${GITHUB_WORKFLOW}" -r "${DESTINATION_BRANCH}"


### PR DESCRIPTION
Previously, the action required a PAT with `repo:write` privileges.

This change removed that requirement, improving security.

This token was required because commits made with the GITHUB_TOKEN do not trigger a workflow re-run. This was solved by re-running the workflow using the gh cli.