### PR TITLE
Updated action tests so they won't push changes during testing

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -46,6 +46,7 @@ jobs:
         uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.4
         with:
           branches_to_skip: master
+          push_changes: false
 
       - name: "Check that action didn't do any changes"
         run: |
@@ -59,8 +60,9 @@ jobs:
         with:
           branches_to_skip: master
           actor: ${{ github.actor }}
+          push_changes: false
 
-      - name: "Check that action pushed update back to the repository"
+      - name: "Check that action committed changes to the repository"
         if: github.ref_type == 'branch'
         run: |
           if [[ "${{ steps.changed-by-dependabot2.outputs.is_dirty }}"  != 'true' ]]; then

--- a/DEPENDENCY_LICENSES.md
+++ b/DEPENDENCY_LICENSES.md
@@ -5,3 +5,6 @@ go-mkopensource incorporates Free and Open Source software under the following l
 * [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
 * [ISC license](https://opensource.org/licenses/ISC)
 * [MIT license](https://opensource.org/licenses/MIT)
+
+
+Dependencies updated by 'Smoke tests' on Wed Feb  8 19:15:23 UTC 2023

--- a/actions/save-dependabot-changes/action.yml
+++ b/actions/save-dependabot-changes/action.yml
@@ -12,6 +12,12 @@ inputs:
     required: true
     default: 'dependabot[bot]'
 
+  push_changes:
+    description: |
+      If true, changes made to dependencies will be pushed to the remote. Used only for testing the action.
+    required: true
+    default: 'true'
+
 outputs:
   is_dirty:
     description: "If there were changes made by dependabot, this variable will be true"
@@ -57,6 +63,8 @@ runs:
 
     - name: Commit updated dependency files
       if: steps.check-dirty.outputs.DIRTY == 'true'
+      env:
+        PUSH_CHANGES: ${{ inputs.push_changes }}
       shell: bash
       run: $GITHUB_ACTION_PATH/commit.sh
 

--- a/actions/save-dependabot-changes/commit.sh
+++ b/actions/save-dependabot-changes/commit.sh
@@ -11,4 +11,6 @@ git checkout "${DESTINATION_BRANCH}"
 echo '::notice:: Committing dependabot changes to DEPENDENCIES.md and/or DEPENDENCY_LICENSES.md'
 git commit -m  "Updated dependency information after dependabot change." DEPENDENCIES.md DEPENDENCY_LICENSES.md go.mod go.sum
 
-git push
+if [[ "${PUSH_CHANGES}" == 'true' ]]; then
+    git push
+fi


### PR DESCRIPTION
This will prevent polluting the branch where a developer is testing changes to the action.

Tests:
Verified that the tests didn't make any commit.