### PR TITLE
Fix go.mod not being copied from the docker image back to the application repo

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: "Verify if changes were made by dependabot"
         id: changed-by-dependabot
-        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.6
+        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.7
         with:
           branches_to_skip: master
           push_changes: false
@@ -61,7 +61,7 @@ jobs:
 
       - name: "Save dependency changes made by the last committer"
         id: changed-by-dependabot2
-        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.6
+        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.7
         with:
           branches_to_skip: master
           actor: ${{ github.actor }}

--- a/build-aux/docker/go_builder.dockerfile
+++ b/build-aux/docker/go_builder.dockerfile
@@ -63,5 +63,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/r
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg/mod \
     if [[ -z "$UNPARSABLE_PACKAGE" ]] ; then /scripts/scan-go.sh; else /scripts/scan-go.sh --unparsable-packages $UNPARSABLE_PACKAGE ; fi
 
+RUN cp go.mod go.sum /temp/
+
 FROM scratch as license_output
 COPY --from=go_dependency_scanner /temp/* /
+COPY --from=go_dependency_scanner /app/go.mod /app/go.sum /

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -121,3 +121,7 @@ fi
     echo -e "\n"
   fi
 ) >"${BUILD_HOME}/DEPENDENCIES.md"
+
+# copy go.mod and go.sum
+cp  "${BUILD_TMP}/go.mod" "${BUILD_HOME}"
+cp  "${BUILD_TMP}/go.sum" "${BUILD_HOME}"


### PR DESCRIPTION
# Description

go-mkopensource will update dependencies as necessary when `go mod vendor` fails, which will change go.mod and go.sum.

When dependency scanning finishes, the modified do.mod/go.sum should also be returned back to the application so they can be commited.

The impact of this issue is that the dependency files will show dependencies that do not match what's in go.mod.

# Tests

Tested from saas_app. This [workflow](https://github.com/datawire/saas_app/actions/runs/4164305580/jobs/7205771757) saves DEPENDENCIES.md as well as go.mod and go.sum.