### PR TITLE
make proprietary packages configurable

### DIFF
--- a/cmd/js-mkopensource/dependency/hardcodeddependencies.go
+++ b/cmd/js-mkopensource/dependency/hardcodeddependencies.go
@@ -15,5 +15,5 @@ var hardcodedJsDependencies = map[string][]string{
 	"pako@1.0.10":                  {MIT.Name},
 	"regenerator-transform@0.10.1": {BSD2.Name},
 	"regjsparser@0.1.5":            {BSD2.Name},
-	"node-forge@1.3.1":		{BSD3.Name},
+	"node-forge@1.3.1":             {BSD3.Name},
 }

--- a/pkg/detectlicense/licenses.go
+++ b/pkg/detectlicense/licenses.go
@@ -162,12 +162,6 @@ func expectsNotice(licenses map[License]struct{}) bool {
 
 func DetectLicenses(packageName string, packageVersion string, files map[string][]byte) (map[License]struct{}, error) {
 
-	if isAmbassadorProprietarySoftware(packageName) {
-		// Ambassador's proprietary software has a proprietary license
-		softwareLicenses := map[License]struct{}{AmbassadorProprietary: {}}
-		return softwareLicenses, nil
-	}
-
 	if knownDependencies, isKnown := knownDependencies(packageName, packageVersion); isKnown {
 		licenses := map[License]struct{}{}
 		for _, license := range knownDependencies {

--- a/pkg/detectlicense/proprietary.go
+++ b/pkg/detectlicense/proprietary.go
@@ -1,0 +1,47 @@
+package detectlicense
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+//nolint:gochecknoglobals // Would be 'const'.
+var ambassadorPrivateRepos = []string{
+	"github.com/datawire/telepresence2-proprietary/",
+	"github.com/datawire/saas_app/",
+	"github.com/datawire/telepresence-pro/",
+}
+
+type AmbassadorProprietarySoftware []string
+
+func GetAmbassadorProprietarySoftware(proprietarySoftware ...string) AmbassadorProprietarySoftware {
+	ambProprietarySoftware := AmbassadorProprietarySoftware{}
+	ambProprietarySoftware = append(ambProprietarySoftware, ambassadorPrivateRepos...)
+	ambProprietarySoftware = append(ambProprietarySoftware, proprietarySoftware...)
+	return ambProprietarySoftware
+}
+
+func (a AmbassadorProprietarySoftware) IsProprietarySoftware(packageName string) bool {
+	for _, proprietarySoftware := range a {
+		if packageName == proprietarySoftware {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *AmbassadorProprietarySoftware) ReadProprietarySoftwareFile(name string) error {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return err
+	}
+
+	var proprietary_software []string
+	if err = yaml.Unmarshal(data, &proprietary_software); err != nil {
+		return err
+	}
+
+	*a = append(*a, proprietary_software...)
+	return nil
+}

--- a/pkg/detectlicense/proprietary_test.go
+++ b/pkg/detectlicense/proprietary_test.go
@@ -19,7 +19,6 @@ func TestReadProprietarySoftwareFile(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, proprietarySoftware, len(ambassadorPrivateRepos)+2)
-	require.Subset(t, proprietarySoftware,
-		[]string{"github.com/datawire/secretprogram", "github.com/datawire/othersecretprogram"},
-	)
+	require.Contains(t, proprietarySoftware, "github.com/datawire/secretprogram")
+	require.Contains(t, proprietarySoftware, "github.com/datawire/othersecretprogram")
 }

--- a/pkg/detectlicense/proprietary_test.go
+++ b/pkg/detectlicense/proprietary_test.go
@@ -1,0 +1,25 @@
+package detectlicense
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAmbassadorProprietarySoftware(t *testing.T) {
+	proprietarySoftware := GetAmbassadorProprietarySoftware("github.com/datawire/secretprogram")
+	require.Len(t, proprietarySoftware, len(ambassadorPrivateRepos)+1)
+	require.Contains(t, proprietarySoftware, "github.com/datawire/secretprogram")
+}
+
+func TestReadProprietarySoftwareFile(t *testing.T) {
+	proprietarySoftware := GetAmbassadorProprietarySoftware()
+
+	err := proprietarySoftware.ReadProprietarySoftwareFile("./testdata/proprietary_software.yaml")
+
+	require.NoError(t, err)
+	require.Len(t, proprietarySoftware, len(ambassadorPrivateRepos)+2)
+	require.Subset(t, proprietarySoftware,
+		[]string{"github.com/datawire/secretprogram", "github.com/datawire/othersecretprogram"},
+	)
+}

--- a/pkg/detectlicense/testdata/proprietary_software.yaml
+++ b/pkg/detectlicense/testdata/proprietary_software.yaml
@@ -1,0 +1,2 @@
+- github.com/datawire/secretprogram
+- github.com/datawire/othersecretprogram

--- a/pkg/detectlicense/validationexceptions.go
+++ b/pkg/detectlicense/validationexceptions.go
@@ -2,16 +2,7 @@ package detectlicense
 
 import (
 	"fmt"
-	"strings"
 )
-
-func isAmbassadorProprietarySoftware(packageName string) bool {
-	const SmartAgentRepo = "github.com/datawire/telepresence2-proprietary/"
-	const AmbassadorCloudRepo = "github.com/datawire/saas_app/"
-	const TelepresencePro = "github.com/datawire/telepresence-pro/"
-
-	return strings.HasPrefix(packageName, SmartAgentRepo) || strings.HasPrefix(packageName, AmbassadorCloudRepo) || strings.HasPrefix(packageName, TelepresencePro)
-}
 
 // knownDependencies will return a list of licenses for any dependency that has been
 // hardcoded due to the difficulty to parse the license file(s).


### PR DESCRIPTION
add an additional flag `--proprietary-software` that points to a YAML file containing proprietary go packages:
```
- github/datawire/foo
- github/datawire/bar
```