### PR TITLE
Delete test data files before NPM dependencies are scanned

### DIFF
--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -21,6 +21,10 @@ fi
 BUILD_SCRIPTS=$(dirname $(realpath "$0"))
 . "${BUILD_SCRIPTS}/docker/imports.sh"
 
+# Delete test data
+rm -fr "${BUILD_SCRIPTS}/../test-data"
+exit
+
 validate_required_variable APPLICATION
 validate_required_variable APPLICATION_TYPE
 validate_required_variable BUILD_HOME


### PR DESCRIPTION
# Description

The dependency generation script was not excluding the NPM test data files during dependency generation, which could add unwanted dependencies to the dependency files.

The script was updated to remove test data files before it runs.