### PR TITLE
Allow passing a list of proprietary dependencies

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -40,7 +40,10 @@ jobs:
           
           # Generate license information
           export GO_IMAGE=$(grep -e 'FROM golang:' "build-aux/docker/go_builder.dockerfile" | cut -d ' ' -f2 )
-          export NPM_PACKAGES=$( echo -e "./test-data/package.json\n./test-data/package-lock.json" )
+
+          #Copy test data to another folder since it can't be used from there
+          cp -a ./test-data ./ui
+          export NPM_PACKAGES=$( echo -e "./ui/package.json\n./ui/package-lock.json" )
           
           mkdir -p "${BUILD_TMP}"
           build-aux/generate.sh --unparsable-packages ./unparsable-packages.yaml

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ We then use the flag `--unparsable-packages unparsable-packages.yaml` when runni
 Example:
 In previous versions of this scanner, sometimes the scanner complains about missing dependencies when the scanner gets
 the list of all the packages in the file "vendor/modules.txt" using the command "go mod vendor" You can see that in the following output.
+
 ```bash
 #26 18.21 go: downloading github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916
 #26 18.24 go: downloading github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
@@ -151,11 +152,33 @@ the list of all the packages in the file "vendor/modules.txt" using the command 
 #26 36.85 /scripts/go-mkopensource: fatal: ["go" "mod" "vendor"]: exit status 1
 #26 ERROR: executor failed running [/bin/sh -c /scripts/scan-go.sh]: exit code: 1
 ```
+
 Now the scanner is smart enough to follow the indications of the "go mod vendor"  install the dependencies, and then 
 get the list of packages from the file ''vendor/modules.txt"
 
 Sometimes it isn't possible to install the dependecies sugested by the "go mod vendor" command. 
 The scanner will complain with the message "Error installing dependency". In this case the project will require human intervention to solve the problem.
+
+Another reason that may cause a failure is the use of our proprietary packages, like `github.com/datawire/telepresence-pro/rpc/proconnector`. 
+The error will message will be similar to this one: 
+
+```bash
+/scripts/go-mkopensource: fatal: 1 license-detection errors:
+  1. Package "github.com/datawire/telepresence-pro/rpc/proconnector": could not identify a license for all sources (had no global LICENSE file)
+```
+
+Fo exclude these packages, add a yaml file like this
+```yaml
+- github.com/datawire/telepresence-pro/rpc/userdaemon
+- github.com/datawire/telepresence-pro/rpc/proconnector
+- github.com/datawire/telepresence2-proprietary/rpc/systema
+```
+
+And pass it to the generate.sh script using the argument `--proprietary-packages`:
+
+```bash
+./generate.sh" --proprietary-packages proprietary-packages.yaml;
+```
 
 ### Remember to always create a ticket!
 When a problem arise, remember to always create a ticket so that the problem can be fixed. This will help all users

--- a/build-aux/docker/go_builder.dockerfile
+++ b/build-aux/docker/go_builder.dockerfile
@@ -33,6 +33,8 @@ RUN mkdir -p "${GOMODCACHE}"
 
 ARG UNPARSABLE_PACKAGE
 ENV UNPARSABLE_PACKAGE="${UNPARSABLE_PACKAGE}"
+ARG PROPRIETARY_PACKAGES
+ENV PROPRIETARY_PACKAGES="${PROPRIETARY_PACKAGES}"
 ARG APPLICATION_TYPE
 ENV APPLICATION_TYPE="${APPLICATION_TYPE}"
 
@@ -59,13 +61,14 @@ RUN chmod +x *.sh go-mkopensource
 WORKDIR /app
 COPY . ./
 
-RUN [[ -z "${UNPARSABLE_PACKAGE}" ]] || stat "${UNPARSABLE_PACKAGE}" > /dev/null
+RUN test -z "${UNPARSABLE_PACKAGE}" || stat "${UNPARSABLE_PACKAGE}" > /dev/null
+RUN test -z "${PROPRIETARY_PACKAGES}" || stat "${PROPRIETARY_PACKAGES}" > /dev/null
 
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg/mod \
     go mod download
 
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg/mod \
-    if [[ -z "$UNPARSABLE_PACKAGE" ]] ; then /scripts/scan-go.sh; else /scripts/scan-go.sh --unparsable-packages $UNPARSABLE_PACKAGE ; fi
+    /scripts/scan-go.sh
 
 RUN cp go.mod go.sum /temp/
 

--- a/build-aux/docker/scan-go.sh
+++ b/build-aux/docker/scan-go.sh
@@ -11,11 +11,19 @@ cd /app
 
 GO_VERSION=$(go version | sed -E 's/.*go([1-9\.]*).*/\1/')
 
-/scripts/go-mkopensource --output-format=txt --package=mod --output-type=markdown --gotar="$(ls /data/go*.src.tar.gz)" \
-  --unparsable-packages="${UNPARSABLE_PACKAGE}" >"${GO_DEPENDENCIES}"
+ADDITIONAL_GENERATE_ARGS=""
+if [[ -n "${UNPARSABLE_PACKAGE}" ]]; then
+    ADDITIONAL_GENERATE_ARGS="--unparsable-packages=${UNPARSABLE_PACKAGE} "
+fi
+if [[ -n "${PROPRIETARY_PACKAGES}" ]]; then
+    ADDITIONAL_GENERATE_ARGS="${ADDITIONAL_GENERATE_ARGS} --proprietary-software=${PROPRIETARY_PACKAGES} "
+fi
+
+/scripts/go-mkopensource --output-format=txt --package=mod --output-type=markdown --gotar="$(ls /data/go*.src.tar.gz)"  \
+    ${ADDITIONAL_GENERATE_ARGS} >"${GO_DEPENDENCIES}"
 
 DEPENDENCY_INFO="${BUILD_TMP}/go_dependencies.json"
 /scripts/go-mkopensource --output-format=txt --package=mod --output-type=json --application-type=${APPLICATION_TYPE} \
-  --unparsable-packages="${UNPARSABLE_PACKAGE}" --gotar="$(ls /data/go*.src.tar.gz)" >"${DEPENDENCY_INFO}"
+    ${ADDITIONAL_GENERATE_ARGS} --gotar="$(ls /data/go*.src.tar.gz)" >"${DEPENDENCY_INFO}"
 
 jq -r '.licenseInfo | to_entries | .[] | "* [" + .key + "](" + .value + ")"' "${DEPENDENCY_INFO}" >"${GO_LICENSES}"

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -10,13 +10,18 @@ archive_dependencies() {
 
 UNPARSABLE_PACKAGE_VALUE=""
 
-if [ $# -gt 0 ]; then
-  if [ "$1" = "--unparsable-packages" ]; then
-    UNPARSABLE_PACKAGE_VALUE="$2"
-
-  fi
-fi
-
+# Parse command line arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+   --unparsable-packages)
+      UNPARSABLE_PACKAGE_VALUE="$2"
+      ;;
+    --proprietary-packages)
+      PROPRIETARY_PACKAGES_VALUE="$2"
+      ;;
+  esac
+  shift
+done
 
 BUILD_SCRIPTS=$(dirname $(realpath "$0"))
 . "${BUILD_SCRIPTS}/docker/imports.sh"
@@ -45,6 +50,7 @@ docker build \
   --build-arg GO_IMAGE="${GO_IMAGE}" \
   --build-arg SCRIPTS_HOME="${SCRIPTS_HOME}" \
   --build-arg UNPARSABLE_PACKAGE="${UNPARSABLE_PACKAGE_VALUE}" \
+  --build-arg PROPRIETARY_PACKAGES="${PROPRIETARY_PACKAGES_VALUE}" \
   -t "go-deps-builder" --target license_output \
   --output "${BUILD_TMP}" .
 popd >/dev/null

--- a/build-aux/generate.sh
+++ b/build-aux/generate.sh
@@ -23,7 +23,6 @@ BUILD_SCRIPTS=$(dirname $(realpath "$0"))
 
 # Delete test data
 rm -fr "${BUILD_SCRIPTS}/../test-data"
-exit
 
 validate_required_variable APPLICATION
 validate_required_variable APPLICATION_TYPE

--- a/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/00-intern-old/expected_err.txt
@@ -7,9 +7,10 @@
 
     Some possible causes for this issue are:
 
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
+    - Dependency is proprietary Ambassador Labs software: Create a yaml
+    file with the proprietary dependencies and pass it to the
+    generate.sh script using the --proprietary-packages command line
+    option.  See the README.md file for more information.
 
     - License information can't be identified: Add an entry to
     hardcodedGoDependencies, hardcodedPythonDependencies or

--- a/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
+++ b/cmd/go-mkopensource/testdata/03-multierror/expected_err.txt
@@ -25,9 +25,10 @@
 
     Some possible causes for this issue are:
 
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
+    - Dependency is proprietary Ambassador Labs software: Create a yaml
+    file with the proprietary dependencies and pass it to the
+    generate.sh script using the --proprietary-packages command line
+    option.  See the README.md file for more information.
 
     - License information can't be identified: Add an entry to
     hardcodedGoDependencies, hardcodedPythonDependencies or

--- a/cmd/js-mkopensource/dependency/testdata/empty-license/expected_err.txt
+++ b/cmd/js-mkopensource/dependency/testdata/empty-license/expected_err.txt
@@ -7,9 +7,10 @@
 
     Some possible causes for this issue are:
 
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
+    - Dependency is proprietary Ambassador Labs software: Create a yaml
+    file with the proprietary dependencies and pass it to the
+    generate.sh script using the --proprietary-packages command line
+    option.  See the README.md file for more information.
 
     - License information can't be identified: Add an entry to
     hardcodedGoDependencies, hardcodedPythonDependencies or

--- a/cmd/js-mkopensource/dependency/testdata/hardcoded-dependencies-but-different-version/expected_err.txt
+++ b/cmd/js-mkopensource/dependency/testdata/hardcoded-dependencies-but-different-version/expected_err.txt
@@ -7,9 +7,10 @@
 
     Some possible causes for this issue are:
 
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
+    - Dependency is proprietary Ambassador Labs software: Create a yaml
+    file with the proprietary dependencies and pass it to the
+    generate.sh script using the --proprietary-packages command line
+    option.  See the README.md file for more information.
 
     - License information can't be identified: Add an entry to
     hardcodedGoDependencies, hardcodedPythonDependencies or

--- a/cmd/js-mkopensource/dependency/testdata/missing-license/expected_err.txt
+++ b/cmd/js-mkopensource/dependency/testdata/missing-license/expected_err.txt
@@ -7,9 +7,10 @@
 
     Some possible causes for this issue are:
 
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
+    - Dependency is proprietary Ambassador Labs software: Create a yaml
+    file with the proprietary dependencies and pass it to the
+    generate.sh script using the --proprietary-packages command line
+    option.  See the README.md file for more information.
 
     - License information can't be identified: Add an entry to
     hardcodedGoDependencies, hardcodedPythonDependencies or

--- a/cmd/js-mkopensource/dependency/testdata/unknown-license/expected_err.txt
+++ b/cmd/js-mkopensource/dependency/testdata/unknown-license/expected_err.txt
@@ -7,9 +7,10 @@
 
     Some possible causes for this issue are:
 
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
+    - Dependency is proprietary Ambassador Labs software: Create a yaml
+    file with the proprietary dependencies and pass it to the
+    generate.sh script using the --proprietary-packages command line
+    option.  See the README.md file for more information.
 
     - License information can't be identified: Add an entry to
     hardcodedGoDependencies, hardcodedPythonDependencies or

--- a/cmd/py-mkopensource/testdata/unknown-license/expected_err.txt
+++ b/cmd/py-mkopensource/testdata/unknown-license/expected_err.txt
@@ -7,9 +7,10 @@
 
     Some possible causes for this issue are:
 
-    - Dependency is proprietary Ambassador Labs software: Update
-    function IsAmbassadorProprietarySoftware() to correctly identify the
-    dependency
+    - Dependency is proprietary Ambassador Labs software: Create a yaml
+    file with the proprietary dependencies and pass it to the
+    generate.sh script using the --proprietary-packages command line
+    option.  See the README.md file for more information.
 
     - License information can't be identified: Add an entry to
     hardcodedGoDependencies, hardcodedPythonDependencies or

--- a/pkg/scanningerrors/explain.go
+++ b/pkg/scanningerrors/explain.go
@@ -46,9 +46,9 @@ var errCategoryExplanations = map[string]string{
 
 		Some possible causes for  this issue are:
 
-		- Dependency is proprietary Ambassador Labs software: Update function 
-		  IsAmbassadorProprietarySoftware() to correctly identify the 
-		  dependency
+		- Dependency is proprietary Ambassador Labs software: Create a yaml file with the proprietary 
+          dependencies and pass it to the generate.sh script using the --proprietary-packages command line option.
+          See the README.md file for more information.
 
 		- License information can't be identified: Add an entry to 
           hardcodedGoDependencies, hardcodedPythonDependencies 


### PR DESCRIPTION
# Description

Add a command line option to the generate script that can be used to pass a list of proprietary licenses that will not be added to the generated output.

There was also a bug in the generate.sh script and it was aborting generation before any change was done. This has been fixed in 0474f48075f08693c489ae94cb4162c51a7a5a38.