### PR TITLE
Do not fail CI for appropriately skipped branch

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -71,7 +71,7 @@ jobs:
           push_changes: false
 
       - name: "Check that action committed changes to the repository"
-        if: github.ref_type == 'branch'
+        if: github.ref_type == 'branch' && !contains(github.ref, 'master')
         run: |
           if [[ "${{ steps.changed-by-dependabot2.outputs.license_information_committed }}"  != 'true' ]]; then
             echo "::error:: Action indicates that the repo was not dirty"


### PR DESCRIPTION
The CI smoke test has been failing when run against the `master` branch (or any branch matching `master` technically), as the logic is currently set to `branches_to_skip: master`, but the subsequent check does not take this into account.

We can make this verification more complex in the future to handle more use-cases, but for now, the coverage is reasonable here.